### PR TITLE
remove `impute` target from top-level makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-projects = chunk concordance impute ligate phase sample snparray
+projects = chunk concordance ligate phase sample snparray
 
 .PHONY: all $(projects)
 


### PR DESCRIPTION
The impute directory had been previously removed, but was still
present at the top-level makefile, which prevents builds.

fixes odelaneau/GLIMPSE#6