### PR TITLE
Fixed dangerous macro expansion

### DIFF
--- a/phase/src/objects/genotype.h
+++ b/phase/src/objects/genotype.h
@@ -26,9 +26,9 @@
 
 #include <utils/otools.h>
 
-#define _SET32(n,i)	(n |= 1U << (i))
-#define _CLR32(n,i)	(n &= ~(1U << (i)));
-#define _GET32(n,i)	((n >> (i)) & 1U);
+#define _SET32(n,i)	((n) |= 1U << (i))
+#define _CLR32(n,i)	((n) &= ~(1U << (i)));
+#define _GET32(n,i)	(((n) >> (i)) & 1U);
 
 // 5 bytes per genotype, but sparse!
 struct inferred_genotype {

--- a/phase/src/objects/genotype.h
+++ b/phase/src/objects/genotype.h
@@ -26,9 +26,9 @@
 
 #include <utils/otools.h>
 
-#define _SET32(n,i)	(n |= 1U << i)
-#define _CLR32(n,i)	(n &= ~(1U << i));
-#define _GET32(n,i)	((n >> i) & 1U);
+#define _SET32(n,i)	(n |= 1U << (i))
+#define _CLR32(n,i)	(n &= ~(1U << (i)));
+#define _GET32(n,i)	((n >> (i)) & 1U);
 
 // 5 bytes per genotype, but sparse!
 struct inferred_genotype {


### PR DESCRIPTION
The macro parameter `i` was unprotected, which may cause problems if operator precedence is not as intended.
E.g.,
`_SET32(n, 2*s+1)` will expand to `(n |= 1 << 2*s+1)` and here `*` and `+` both have precedence on `<<` so it works but
`_SET32(n, cond ? 2 : 1)` will expand to `(n |= 1 << cond ? 2 : 1)` and due to precedence of `<<` over `a ? b : c` this will evaluate `1 << cond` as the condition for the `?` operator and return an unexpected result.

Fix : Protect your macro parameters with `()` so that the order of operations is always the intended one.