### PR TITLE
Changing delete iteration in glimpse-phase destructor

### DIFF
--- a/phase/src/caller/caller_management.cpp
+++ b/phase/src/caller/caller_management.cpp
@@ -36,13 +36,20 @@ caller::caller():
 
 caller::~caller()
 {
-	for (int t = 0 ; t < HMM.size() ; t ++) {
+	for (int t = 0; t < HMM.size(); t++)
+	{
 		delete HMM[t];
-		delete DMM[t];
-		delete COND[t];
 	}
 	HMM.clear();
+	for (int t = 0; t < DMM.size(); t++)
+	{
+		delete DMM[t];
+	}
 	DMM.clear();
+	for (int t = 0; t < COND.size(); t++)
+	{
+		delete COND[t];
+	}
 	COND.clear();
 }
 


### PR DESCRIPTION
When working only with the male chromosome the program stops with "core dumped" after the finalization step, as reported in #54 . This PR solves it.
