### PR TITLE
fix string_utils.h warning:

### DIFF
--- a/chunk/src/utils/string_utils.h
+++ b/chunk/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/concordance/src/utils/string_utils.h
+++ b/concordance/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/ligate/src/utils/string_utils.h
+++ b/ligate/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/phase/src/utils/string_utils.h
+++ b/phase/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/sample/src/utils/string_utils.h
+++ b/sample/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/snparray/src/utils/string_utils.h
+++ b/snparray/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}

--- a/stats/src/utils/string_utils.h
+++ b/stats/src/utils/string_utils.h
@@ -63,7 +63,7 @@ public:
 	template < class T >
 	std::string str(T n, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		ss << n;
 		return ss.str();
 	}
@@ -71,7 +71,7 @@ public:
 	template < class T >
 	std::string str(std::vector < T > & v, int prec = -1) {
 		std::ostringstream ss( std::stringstream::out );
-		if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
+		if (prec >= 0) { ss << std::setiosflags( std::ios::fixed ); ss.precision(prec); }
 		for (int e = 0 ; e < v.size() ; e ++) ss << (e>0?" ":"") << v[e] ;
 		return ss.str();
 	}


### PR DESCRIPTION
On OSX, I was getting warnings like:

```console
src/utils/string_utils.h:74:26: error: use of undeclared identifier 'setiosflags'; did you mean 'std::setiosflags'?
                if (prec >= 0) { ss << setiosflags( std::ios::fixed ); ss.precision(prec); }
```