### PR TITLE
Add stats tool to the root makefile.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-projects = chunk concordance ligate phase sample snparray
+projects = chunk concordance ligate phase sample snparray stats
 
 .PHONY: all $(projects)
 


### PR DESCRIPTION
The makefile in the root folder of the directory does not compile the stats tool.
I believe it is a mistake, and this PR aims at fixing that.