### PR TITLE
rsquared.spl output contains r and not r^2

### DIFF
--- a/concordance/src/containers/call_set_writing.cpp
+++ b/concordance/src/containers/call_set_writing.cpp
@@ -484,7 +484,7 @@ void call_set::writeData(std::string fout) {
 	{
 		double rsq_gt = rsquared_spl_gt_all[i].corrXY();
 		double rsq_ds = rsquared_spl_ds_all[i].corrXY();
-		fd5 << samples[i] << " " << rsq_gt << " " << rsq_ds << std::endl;
+		fd5 << samples[i] << " " << rsq_gt*rsq_gt << " " << rsq_ds*rsq_ds << std::endl;
 	}
 	fd5.close();
 }


### PR DESCRIPTION
Hi, I think there is a small bug in the code that writes the rsquared.spl.txt.gz output.
The CorrXY() function returns the Pearson r from what I understand and this is not squared as the filename would suggest.