### PR TITLE
Specify index associated with BAM/CRAM file

### DIFF
--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -231,16 +231,16 @@ void caller::setup_mpileup()
 		{
 			if (stb.split(buffer, btokens, " 	") > 3 || btokens.size() < 1) vrb.error("Bam list should contain only one, two, or three columns");
 			auto ret0 = sbams.insert(btokens[0]);
-			if (ret0.second==false) vrb.error("Repeated filename in bam list: " + btokens[0]);
+			if (!ret0.second) vrb.error("Repeated filename in bam list: " + btokens[0]);
 			M.bam_fnames.push_back(btokens[0]);
 
 			std::string name;
 			std::string bai;
-			if (btokens.size == 3) {
+			if (btokens.size() == 3) {
 				bai = btokens[1]
 				name = btokens[2]
 				
-			} else if (btokens.size ==2) {
+			} else if (btokens.size() ==2) {
 				std::string ext = stb.get_extension(btokens[1]);
 				if (ext == ".bai" || ext == ".csi" || ext == ".crai") {
 					bai = btoken[1];
@@ -251,7 +251,7 @@ void caller::setup_mpileup()
 
 			if (!bai.empty()) {
 				auto ret_bai = sbais.insert(bai);
-				if (ret_bai.second==false) vrb.error("Repeated filename in bai list: " + bai);
+				if (!ret_bai.second) vrb.error("Repeated filename in bai list: " + bai);
 				M.bai_fnames.push_back(bai);
 			}
 
@@ -259,8 +259,8 @@ void caller::setup_mpileup()
 				name = stb.remove_ext(stb.extract_file_name(btokens[1]));
 			}
 
-			auto ret1_name = snames.insert(name);
-			if (ret_name.second==false) vrb.error("Repeated sample name in bam list: " + name);
+			auto ret_name = snames.insert(name);
+			if (!ret_name.second) vrb.error("Repeated sample name in bam list: " + name);
 			M.tar_sample_names.push_back(name);
 		}
 		fd.close();

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -237,8 +237,8 @@ void caller::setup_mpileup()
 			std::string name;
 			std::string bai;
 			if (btokens.size() == 3) {
-				bai = btokens[1]
-				name = btokens[2]
+				bai = btokens[1];
+				name = btokens[2];
 				
 			} else if (btokens.size() ==2) {
 				std::string ext = stb.get_extension(btokens[1]);

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -249,13 +249,13 @@ void caller::setup_mpileup()
 				}
 			}
 
-			if (bai != 0) {
+			if (!bai.empty()) {
 				auto ret_bai = sbais.insert(bai);
 				if (ret_bai.second==false) vrb.error("Repeated filename in bai list: " + bai);
 				M.bai_fnames.push_back(bai);
 			}
 
-			if (name == 0) {
+			if (name.empty()) {
 				name = stb.remove_ext(stb.extract_file_name(btokens[1]));
 			}
 

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -243,7 +243,7 @@ void caller::setup_mpileup()
 			} else if (btokens.size() ==2) {
 				std::string ext = stb.get_extension(btokens[1]);
 				if (ext == ".bai" || ext == ".csi" || ext == ".crai") {
-					bai = btoken[1];
+					bai = btokens[1];
 				} else {
 					std::string name = btokens[1];
 				}

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -223,20 +223,44 @@ void caller::setup_mpileup()
 		input_file fd (options["bam-list"].as < std::string >());
 	    if (!fd.good()) vrb.error("Reading bam list: [" + options["bam-list"].as < std::string >() + "]");
 
-		std::vector<std::string> btokens(2);
+		std::vector<std::string> btokens(3);
 		std::set<std::string> sbams;
+		std::set<std::string> sbais;
 		std::set<std::string> snames;
 		while (getline(fd, buffer))
 		{
-			if (stb.split(buffer, btokens, " 	") > 2 || btokens.size() < 1) vrb.error("Bam list should contain only one or two columns");
+			if (stb.split(buffer, btokens, " 	") > 3 || btokens.size() < 1) vrb.error("Bam list should contain only one, two, or three columns");
 			auto ret0 = sbams.insert(btokens[0]);
-			if (ret0.second==false) vrb.error("Repeated filename in bam list: " + M.bam_fnames.back());
+			if (ret0.second==false) vrb.error("Repeated filename in bam list: " + btokens[0]);
 			M.bam_fnames.push_back(btokens[0]);
 
-			std::string name = btokens[btokens.size() > 1];
-			if (btokens.size() == 1) name = stb.remove_ext(stb.extract_file_name(name));
-			auto ret1 = snames.insert(name);
-			if (ret1.second==false) vrb.error("Repeated sample name in bam list: " + name);
+			std::string name;
+			std::string bai;
+			if (btokens.size == 3) {
+				bai = btokens[1]
+				name = btokens[2]
+				
+			} else if (btokens.size ==2) {
+				std::string ext = stb.get_extension(btokens[1]);
+				if (ext == ".bai" || ext == ".csi" || ext == ".crai") {
+					bai = btoken[1];
+				} else {
+					std::string name = btokens[1];
+				}
+			}
+
+			if (bai != 0) {
+				auto ret_bai = sbais.insert(bai);
+				if (ret_bai.second==false) vrb.error("Repeated filename in bai list: " + bai);
+				M.bai_fnames.push_back(bai);
+			}
+
+			if (name == 0) {
+				name = stb.remove_ext(stb.extract_file_name(btokens[1]));
+			}
+
+			auto ret1_name = snames.insert(name);
+			if (ret_name.second==false) vrb.error("Repeated sample name in bam list: " + name);
 			M.tar_sample_names.push_back(name);
 		}
 		fd.close();
@@ -250,6 +274,10 @@ void caller::setup_mpileup()
     	M.tar_sample_names = std::vector<std::string>(1);
     	if (options.count("ind-name")) M.tar_sample_names[0] = options["ind-name"].as<std::string>();
     	else M.tar_sample_names[0] = stb.remove_ext(stb.extract_file_name(M.bam_fnames[0]));
+		if (options.count("bai-file")) {
+			M.bai_fnames = std::vector<std::string>(1);
+			M.bai_fnames[0] = options["bai-file"].as<std::string>();
+		}
     }
     if (M.n_tar_samples == 0) vrb.error("No input BAM file given.");
 }

--- a/phase/src/caller/caller_parameters.cpp
+++ b/phase/src/caller/caller_parameters.cpp
@@ -37,7 +37,8 @@ void caller::declare_options() {
 	bpo::options_description opt_input ("Input parameters");
 	opt_input.add_options()
 			("bam-file", bpo::value < std::string >(), "Input BAM/CRAM file containing low-coverage sequencing reads. Only one of the following options can be declared: --input-gl, --bam-file, --bam-list.")
-			("bam-list", bpo::value < std::string >(), "List (.txt file) of input BAM/CRAM files containing low-coverage sequencing reads. One file per line. A second column (space separated) can be used to specify the sample name, otherwise the name of the file is used. Only one of the following options can be declared: --input-gl, --bam-file, --bam-list.")
+			("bai-file", bpo::value < std::string >(), "Input BAI/CRAI index associated with BAM/CRAM.  Can be used to specify index if not stored next to BAM/CRAM")
+			("bam-list", bpo::value < std::string >(), "List (.txt file) of input BAM/CRAM files containing low-coverage sequencing reads. One file per line. A second column (space separated) can be used to specify the sample name, or an associated index file.  If index file is specified in second column, sample name can be specified in third column.  If sample name is not specified in second or third column, the name of the file is used. Only one of the following options can be declared: --input-gl, --bam-file, --bam-list.")
 			("input-gl", bpo::value < std::string >(), "VCF/BCF file containing the genotype likelihoods. Only one of the following options can be declared: --input-gl, --bam-file, --bam-list.")
 			("reference,R", bpo::value < std::string >(), "Haplotype reference in VCF/BCF or binary format")
 			("map,M", bpo::value < std::string >(), "Genetic map")

--- a/phase/src/containers/glimpse_mpileup.h
+++ b/phase/src/containers/glimpse_mpileup.h
@@ -126,6 +126,7 @@ public:
 	virtual ~glimpse_mpileup();
 
 	std::vector<std::string> bam_fnames;
+	std::vector<std::string> bai_fnames;
 	std::vector<std::string> tar_sample_names;
 
 	//samples

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -163,7 +163,7 @@ void genotype_bam_caller::call_mpileup(int i)
 	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
 
 	if (mpileup_data.bai_fnames.empty()) {
-		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames.c_str());
+		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames[i].c_str());
 	} else {
 		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());
 	}

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -162,7 +162,7 @@ void genotype_bam_caller::call_mpileup(int i)
 	aux_data.hdr  = sam_hdr_read(aux_data.fp);
 	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
 
-	if (mpileup_data.bai_fnames != 0) {
+	if (mpileup_data.bai_fnames.is_empty()) {
 		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames.c_str());
 	} else {
 		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -162,7 +162,11 @@ void genotype_bam_caller::call_mpileup(int i)
 	aux_data.hdr  = sam_hdr_read(aux_data.fp);
 	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
 
-	aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());
+	if (mpileup_data.bai_fnames != 0) {
+		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames.c_str());
+	} else {
+		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());
+	}
 	if (aux_data.idx == NULL) vrb.error("Failed to load index for [" + mpileup_data.bam_fnames[i] + "]");
 	aux_data.iter = sam_itr_querys(aux_data.idx, aux_data.hdr, region.c_str());
 	if ( aux_data.iter==NULL  ) vrb.error("Failed to load region: [" + region + "] for file: [" + mpileup_data.bam_fnames[i] + "]");

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -162,7 +162,7 @@ void genotype_bam_caller::call_mpileup(int i)
 	aux_data.hdr  = sam_hdr_read(aux_data.fp);
 	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
 
-	if (mpileup_data.bai_fnames.empty()) {
+	if (!mpileup_data.bai_fnames.empty()) {
 		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames[i].c_str());
 	} else {
 		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -162,7 +162,7 @@ void genotype_bam_caller::call_mpileup(int i)
 	aux_data.hdr  = sam_hdr_read(aux_data.fp);
 	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
 
-	if (mpileup_data.bai_fnames.is_empty()) {
+	if (mpileup_data.bai_fnames.empty()) {
 		aux_data.idx = sam_index_load2(aux_data.fp, mpileup_data.bam_fnames[i].c_str(), mpileup_data.bai_fnames.c_str());
 	} else {
 		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());


### PR DESCRIPTION
Adds option to specify index files for BAM/CRAM, in case those index files are not located directly next to BAM/CRAM files.