### PR TITLE
Add retries in case of network errors, and check for sam read errors during pileup calling

### DIFF
--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -166,11 +166,12 @@ void genotype_bam_caller::call_mpileup(int i)
 	int n_retry_remain = n_retry;
 	std::chrono::seconds delay(1);
 	for (; n_retry_remain > 0;n_retry_remain--, delay*=2) {
-		caller.ploidy = mpileup_data.tar_ploidy[i];
 		if (n_retry_remain != n_retry) {
 			std::this_thread::sleep_for(delay);
 			clean();
 		}
+		caller.ploidy = mpileup_data.tar_ploidy[i];
+
 		aux_data.fp = sam_open(mpileup_data.bam_fnames[i].c_str(), "r");
 		if (aux_data.fp == nullptr) {
 			vrb.warning("Cannot open BAM/CRAM file: [" + mpileup_data.bam_fnames[i] + "], " + std::to_string(n_retry_remain) + " retries remaining");

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -159,13 +159,14 @@ genotype_bam_caller::~genotype_bam_caller()
 
 void genotype_bam_caller::call_mpileup(int i)
 {
-	caller.ploidy = mpileup_data.tar_ploidy[i];
+	
 
 	//Retries are not implemented in hfile_libcurl, which ends up being used if streaming from cloud location.  So implementing here. 
 	const int n_retry = 3;
 	int n_retry_remain = n_retry;
 	std::chrono::seconds delay(1);
 	for (; n_retry_remain > 0;n_retry_remain--, delay*=2) {
+		caller.ploidy = mpileup_data.tar_ploidy[i];
 		if (n_retry_remain != n_retry) {
 			std::this_thread::sleep_for(delay);
 			clean();

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -24,6 +24,8 @@
  ******************************************************************************/
 
 #include <io/genotype_bam_caller.h>
+#include <thread>
+#include <chrono>
 
 static int read_bam(void *data, bam1_t *b)
 {
@@ -137,6 +139,12 @@ void genotype_bam_caller::clean()
 	caller.ploidy=0;
 }
 
+void genotype_bam_caller::reset_results(int i)
+{
+	G.stats.cov_ind[i].clear()
+	std::fill(G.stats.depth_count[i].begin(), G.stats.depth_count[i].end(), 0)
+}
+
 genotype_bam_caller::~genotype_bam_caller()
 {
 	if ( aux_data.iter) hts_itr_destroy(aux_data.iter);
@@ -153,21 +161,62 @@ void genotype_bam_caller::call_mpileup(int i)
 {
 	caller.ploidy = mpileup_data.tar_ploidy[i];
 
-	aux_data.fp = sam_open(mpileup_data.bam_fnames[i].c_str(), "r");
-	if (aux_data.fp == nullptr) vrb.error("Cannot open BAM/CRAM file: [" + mpileup_data.bam_fnames[i] + "]");
+	//Retries are not implemented in hfile_libcurl, which ends up being used if streaming from cloud location.  So implementing here. 
+	const int n_retry = 3;
+	int n_retry_remain = n_retry;
+	std::chrono::seconds delay(1);
+	for (; n_retry_remain > 0;n_retry_remain--, delay*=2) {
+		if (n_retry_remain != n_retry) {
+			std::this_thread::sleep_for(delay);
+			clean();
+		}
+		aux_data.fp = sam_open(mpileup_data.bam_fnames[i].c_str(), "r");
+		if (aux_data.fp == nullptr) {
+			vrb.warning("Cannot open BAM/CRAM file: [" + mpileup_data.bam_fnames[i] + "], " + std::to_string(n_retry_remain) + " retries remaining");
+			continue;
+		}
 
-	if (hts_set_opt(aux_data.fp, CRAM_OPT_DECODE_MD, 0)) vrb.error("Failed to set CRAM_OPT_DECODE_MD value");
-	if (!mpileup_data.fai_fname.empty()) if (hts_set_fai_filename(aux_data.fp, mpileup_data.fai_fname.c_str()) != 0)  vrb.error("Failed to process fasta");
+		if (hts_set_opt(aux_data.fp, CRAM_OPT_DECODE_MD, 0)) {
+			vrb.warning("Failed to set CRAM_OPT_DECODE_MD value, " + std::to_string(n_retry_remain) + " retries remaining");
+			continue;
+		}
+		if (!mpileup_data.fai_fname.empty()) {
+			if (hts_set_fai_filename(aux_data.fp, mpileup_data.fai_fname.c_str()) != 0)  {
+				vrb.warning("Failed to process fasta," + std::to_string(n_retry_remain) + " retries remaining");
+				continue;
+			}
+		}
 
-	aux_data.hdr  = sam_hdr_read(aux_data.fp);
-	if ( !aux_data.hdr ) vrb.error("Failed to read header: " + mpileup_data.bam_fnames[i] + ".");
+		aux_data.hdr  = sam_hdr_read(aux_data.fp);
+		if ( !aux_data.hdr ) {
+			vrb.warning("Failed to read header: " + mpileup_data.bam_fnames[i] + ". " + std::to_string(n_retry_remain) + " retries remaining");
+			continue;
+		}
 
-	aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());
-	if (aux_data.idx == NULL) vrb.error("Failed to load index for [" + mpileup_data.bam_fnames[i] + "]");
-	aux_data.iter = sam_itr_querys(aux_data.idx, aux_data.hdr, region.c_str());
-	if ( aux_data.iter==NULL  ) vrb.error("Failed to load region: [" + region + "] for file: [" + mpileup_data.bam_fnames[i] + "]");
+		aux_data.idx = sam_index_load(aux_data.fp, mpileup_data.bam_fnames[i].c_str());
+		if (aux_data.idx == NULL) {
+			vrb.warning("Failed to load index for [" + mpileup_data.bam_fnames[i] + "], " + std::to_string(n_retry_remain) + " retries remaining");
+			continue;
+		}
 
-	glimpse_mpileup_reg(i);
+		aux_data.iter = sam_itr_querys(aux_data.idx, aux_data.hdr, region.c_str());
+		if ( aux_data.iter==NULL  ) {
+			vrb.warning("Failed to load region: [" + region + "] for file: [" + mpileup_data.bam_fnames[i] + "], " + std::to_string(n_retry_remain) + " retries remaining");
+			continue;
+		}
+
+		if (glimpse_mpileup_reg(i) < 0) {
+			vrb.warning("Failed to perform pileup calling for file: [" + mpileup_data.bam_fnames[i] + "], " + std::to_string(n_retry_remain) + " retries remaining");
+			reset_results(i);
+			continue;
+		}
+		break;
+
+	}
+
+	if (n_retry_remain == 0) {
+		vrb.error("Max number of retries attempted.");
+	}
 	clean();
 }
 
@@ -224,6 +273,7 @@ int genotype_bam_caller::glimpse_mpileup_reg(int i)
 			++i_site;
 		}
 	}
+
 	while (i_site < n_sites_reg)
 	{
 		++G.stats.depth_count[i][0];
@@ -235,7 +285,7 @@ int genotype_bam_caller::glimpse_mpileup_reg(int i)
 
 	bam_plp_reset(caller.s_plp);
 	bam_plp_destroy(caller.s_plp);
-    return 0;
+    return call.n_plp < 0 ? -1 : 0;
 }
 
 

--- a/phase/src/io/genotype_bam_caller.cpp
+++ b/phase/src/io/genotype_bam_caller.cpp
@@ -141,8 +141,8 @@ void genotype_bam_caller::clean()
 
 void genotype_bam_caller::reset_results(int i)
 {
-	G.stats.cov_ind[i].clear()
-	std::fill(G.stats.depth_count[i].begin(), G.stats.depth_count[i].end(), 0)
+	G.stats.cov_ind[i].clear();
+	std::fill(G.stats.depth_count[i].begin(), G.stats.depth_count[i].end(), 0);
 }
 
 genotype_bam_caller::~genotype_bam_caller()
@@ -285,7 +285,7 @@ int genotype_bam_caller::glimpse_mpileup_reg(int i)
 
 	bam_plp_reset(caller.s_plp);
 	bam_plp_destroy(caller.s_plp);
-    return call.n_plp < 0 ? -1 : 0;
+    return caller.n_plp < 0 ? -1 : 0;
 }
 
 

--- a/phase/src/io/genotype_bam_caller.h
+++ b/phase/src/io/genotype_bam_caller.h
@@ -79,6 +79,7 @@ public:
 
 	void call_mpileup(int i);
 	void clean();
+	void reset_results();
 	int glimpse_mpileup_reg(int i);
 };
 

--- a/phase/src/io/genotype_bam_caller.h
+++ b/phase/src/io/genotype_bam_caller.h
@@ -79,7 +79,7 @@ public:
 
 	void call_mpileup(int i);
 	void clean();
-	void reset_results();
+	void reset_results(int i);
 	int glimpse_mpileup_reg(int i);
 };
 


### PR DESCRIPTION
This PR adds a safety check to ensure that input bams/crams are fully read in, as well as adding a retry mechanism to avoid failing in case of network issues during i/o.

### Safety Check
Currently, if reading in of a bam/cram fails during pileup calling, Glimpse will happily move on with only part of the bam/cram read in.  The result can be the appearance of 0 coverage, or an artificially high number of uncovered sites.  This is actually a bug that was probably ported over from bcftools (see samtools/bcftools#2177, samtools/samtools#1379).  The fix here, of checking that `caller.n_plp >= 0` is based on the way this is handled in [samtools phase](https://github.com/jmarshall/samtools/blob/cc18465c7349a5bae00618b805d3df1a16b1801b/phase.c#L793), for example.  

There may be other ways that this bug can be hit, but I specifically saw it when running on a large number of crams streaming from GCP in a highly parallelized cloud setup.  The resulting queries to the google api can lead to 429 errors which can then hit this bug.

Technically, even with this fix, a cram can still be partially read in and then a failure to read the rest of the cram won't be caught, if the failure occurs right and the end of a cram container.  This will at least print a warning from htslib that the cram doesn't contain an EOF, but Glimpse will continue on and return a non-zero exit code.  As far as I can tell there is no way to catch this edge case in Glimpse without modifying htslib, so the best idea I've been able to come up with is to have pipelines watch for the htslib warning message and fail if it is seen. 

### Retries
Along this same situation as above, if the 429 error occurs during the loading of the file, Glimpse will fail, which is better than ignoring the error, but can lead to issues if the 429 error rate is high enough to make running the tool impractical.  Unfortunately, retries are not implemented in the htslib curl library, so I instead implemented a simple retry on the Glimpse side.      
