### PR TITLE
phase: caller: Print caller options correctly

### DIFF
--- a/phase/src/caller/caller_parameters.cpp
+++ b/phase/src/caller/caller_parameters.cpp
@@ -350,7 +350,7 @@ void caller::verbose_options()
 	{
 		vrb.title("Genotype calling:");
 		vrb.bullet("Calling model        : [" + options["call-model"].as <std::string> () + "]");
-		vrb.bullet("Indels model         : [" + options.count("call-indels") ? "Perform calling]" : "Haplotype scaffold]");
+		vrb.bullet("Indels model         : [" + stb.str(options.count("call-indels") ? "Perform calling]" : "Haplotype scaffold]"));
 
 		vrb.title("BAM/CRAM filters and options:");
 		vrb.bullet("Min mapping quality  : [" + stb.str(options["mapq"].as <int> ()) + "]");
@@ -368,7 +368,7 @@ void caller::verbose_options()
 	}
 	else
 	{
-		vrb.bullet("use-gl-indels         : [" + options.count("call-indels") ? "Use PLs]" : "Haplotype scaffold]");
+		vrb.bullet("use-gl-indels         : [" + stb.str(options.count("call-indels") ? "Use PLs]" : "Haplotype scaffold]"));
 	}
 
 	vrb.title("Other parameters");


### PR DESCRIPTION
For some options the string concatenation was broken. Fix in the same way it is done for the other options.

Fixes : https://github.com/odelaneau/GLIMPSE/issues/240