### PR TITLE
phase: models: use signed char instead of char

### DIFF
--- a/phase/src/models/phasing_hmm.cpp
+++ b/phase/src/models/phasing_hmm.cpp
@@ -74,7 +74,7 @@ void phasing_hmm::reallocate(const std::vector < bool > & H0, const std::vector 
 
 		if ((!flat[C->polymorphic_sites[l]]) && (!C->lq_flag[C->polymorphic_sites[l]])) {
 			if (a0 != a1) {
-				VAR_TYP.push_back((char)(n_het % 3));
+				VAR_TYP.push_back(n_het % 3);
 				VAR_ALT.push_back(a0);
 				VAR_ABS.push_back(C->polymorphic_sites[l]);
 				VAR_REL.push_back(l);

--- a/phase/src/models/phasing_hmm.h
+++ b/phase/src/models/phasing_hmm.h
@@ -61,7 +61,7 @@ private:
 	conditioning_set * C;
 
 	//EXTERNAL DATA
-	std::vector < char > VAR_TYP;
+	std::vector < signed char > VAR_TYP;
 	std::vector < bool > VAR_ALT;
 	std::vector < int > VAR_ABS;
 	std::vector < int > VAR_REL;


### PR DESCRIPTION
Because the C/C++ standard does not specify the signedness of the char type the results will be compiler/machine dependent this can lead to unexpected behaviour.

Use signed char instead of char to avoid these cases.

References :
- https://stackoverflow.com/questions/2054939/is-char-signed-or-unsigned-by-default
- https://gcc.gnu.org/onlinedocs/gcc-4.2.2/gcc/C-Dialect-Options.html
- https://www.open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf

Fixes : https://github.com/odelaneau/GLIMPSE/issues/242