### PR TITLE
Fix bug in recursive chunking algorithm (and boost download path in Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /docker_build/
 RUN apt-get update && apt-get install -y build-essential libbz2-dev libcurl4-openssl-dev autoconf libssl-dev wget zlib1g-dev liblzma-dev libdeflate-dev
 
 # Download and build boost program_options and iostreams
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz && \
+RUN wget https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.gz && \
 tar -xf boost_1_78_0.tar.gz && \
 rm boost_1_78_0.tar.gz && \
 cd boost_1_78_0/ && \

--- a/chunk/src/chunker/chunker_algorithm.cpp
+++ b/chunk/src/chunker/chunker_algorithm.cpp
@@ -28,7 +28,10 @@
 
 void chunker::split_recursive(output_file & fd, long int & cidx, std::string & chr, long int start_idx, long int stop_idx) {
 	cnk_info.reset();
+	split_recursive_no_reset(fd, cidx, chr, start_idx, stop_idx);
+}
 
+void chunker::split_recursive_no_reset(output_file & fd, long int & cidx, std::string & chr, long int start_idx, long int stop_idx) {
 	// Compute current window properties
 	assert(stop_idx>start_idx);
 	long int curr_window_count = stop_idx - start_idx + 1;
@@ -75,8 +78,8 @@ void chunker::split_recursive(output_file & fd, long int & cidx, std::string & c
 	// If we can further split, recursion!
 	if (next0_window_okay && next1_window_okay) {
 		vrb.bullet("long internal window [" + chr + ":" + stb.str(positions_all_mb[start_idx]) + "-" + stb.str(positions_all_mb[stop_idx]) + "] / L=" + stb.str(curr_window_cm_size) + "cM / L=" + stb.str(curr_window_mb_size) + "bp / C=" + stb.str(curr_window_count));
-		split_recursive (fd, cidx, chr, start_idx, mid_idx);
-		split_recursive (fd, cidx, chr, mid_idx+1, stop_idx);
+		split_recursive_no_reset (fd, cidx, chr, start_idx, mid_idx);
+		split_recursive_no_reset (fd, cidx, chr, mid_idx+1, stop_idx);
 	} else {
 		long int left_idx = -1; long int right_idx=-1;
 		add_buffer(start_idx, stop_idx, left_idx, right_idx);

--- a/chunk/src/chunker/chunker_header.h
+++ b/chunk/src/chunker/chunker_header.h
@@ -147,6 +147,7 @@ public:
 
 	//FILE I/O
 	void split_recursive(output_file &, long int &, std::string &, long int, long int);
+	void split_recursive_no_reset(output_file &, long int &, std::string &, long int, long int);
 	void split_sequential(output_file &, long int &, std::string &, long int, long int, const bool);
 	void add_buffer(const long int, const long int, long int&, long int&);
 	void chunk();


### PR DESCRIPTION
The recursive chunking algorithm currently has a bug where all chunking information is reset in the beginning of the recursive function. Therefore, every time this function is called recursively, all information about previous chunks gets lost and the result is an output file only containing one line of the last chunk, with no error message and a success return code. Note that this does not only occur when explicitly running the program with the `--recursive` but also with the recommended `--sequential` option if it fails to come to a solution within 10,000 iterations.

I fixed this issue by creating a new function that doesn't reset the `cnk_info` object and calling that function from within the recursive algorithm.

Also the path to Boost in the Dockerfile doesn't work anymore so I fixed that.