### PR TITLE
Fix signed integer overflow in phasing HMM array indexing

### DIFF
--- a/phase/src/models/phasing_hmm.cpp
+++ b/phase/src/models/phasing_hmm.cpp
@@ -220,7 +220,7 @@ void phasing_hmm::backward() {
 		if (curr_segment_locus == 0) {
 			SUMK();
 			//phasingProb[curr_segment_index] = prob;
-			std::copy(prob.begin(), prob.end(), phasingProb.begin()+curr_segment_index*C->n_states*HAP_NUMBER);
+			std::copy(prob.begin(), prob.end(), phasingProb.begin()+(size_t)curr_segment_index*C->n_states*HAP_NUMBER);
 			//phasingProbSum[curr_segment_index] = probSumH;
 			std::copy(probSumH.begin(), probSumH.end(), phasingProbSum.begin()+curr_segment_index*HAP_NUMBER);
 			phasingProbSumSum[curr_segment_index] = probSumT;
@@ -229,7 +229,7 @@ void phasing_hmm::backward() {
 		//STORE PROBS FOR PHASING RARE HETS
 		if (VAR_TYP[curr_idx_locus] == VAR_FLAT_HET) {
 			//imputeProb[curr_missing_locus] = prob;
-			std::copy(prob.begin(), prob.end(), imputeProb.begin()+curr_missing_locus*C->n_states*HAP_NUMBER);
+			std::copy(prob.begin(), prob.end(), imputeProb.begin()+(size_t)curr_missing_locus*C->n_states*HAP_NUMBER);
 			//imputeProbSum[curr_missing_locus] = probSumH;
 			std::copy(probSumH.begin(), probSumH.end(), imputeProbSum.begin()+curr_missing_locus*HAP_NUMBER);
 			imputeProbSumSum[curr_missing_locus] = probSumT;

--- a/phase/src/models/phasing_hmm.h
+++ b/phase/src/models/phasing_hmm.h
@@ -289,7 +289,7 @@ void phasing_hmm::SUMK() {
 inline
 bool phasing_hmm::TRANS_HAP()
 {
-	const int states_haps = C->n_states*HAP_NUMBER;
+	const size_t states_haps = (size_t)C->n_states*HAP_NUMBER;
 	sumHProbs = 0.0f;
 	yt = C->getTransition(VAR_ABS[curr_idx_locus], VAR_ABS[curr_idx_locus+1]);
 	nt = 1.0f - yt;
@@ -327,7 +327,7 @@ bool phasing_hmm::SAMPLE_DIP() {
 inline
 void phasing_hmm::IMPUTE_FLAT_HET()
 {
-	const int states_haps = C->n_states*HAP_NUMBER;
+	const size_t states_haps = (size_t)C->n_states*HAP_NUMBER;
 	const __m256 _one = _mm256_set1_ps(1.0f);
 	const __m256 _zero = _mm256_set1_ps(0.0f);
 	__m256 _scaleR = _mm256_load_ps(&imputeProbSum[curr_missing_locus*HAP_NUMBER]);


### PR DESCRIPTION
When GLIMPSE2_phase is run with a reference panel where the number of haplotypes exceeds or equals Kpbwt (default 2000), PBWT selection is skipped and all haplotypes are used as conditioning states. Combined with a low-coverage sample that produces many "flat" heterozygous sites (sites with no informative reads), the array index arithmetic in phasing_hmm overflows a 32-bit signed integer, causing undefined behavior that manifests as either rapid memory blowup and OOM on Linux, or a bus error (`EXC_BAD_ACCESS`) on macOS.

The problem was reproduced with a panel of 1964 haplotypes and a 0.19x coverage sample on a chunk with 617,768 polymorphic sites. With PBWT selection skipped, `n_states=1964` and `n_miss=140,611` (flat het count).

In `IMPUTE_FLAT_HET()` (`phasing_hmm.h`), the index into `imputeProb` is computed as:

```
    imputeProb[curr_missing_locus * states_haps + i]
```

where `curr_missing_locus` is int, and `states_haps` was declared as:

```
    const int states_haps = C->n_states * HAP_NUMBER;  // 1964*8 = 15712
```

When `curr_missing_locus` reaches ~136,500, the product `curr_missing_locus * states_haps` exceeds INT_MAX (2,147,483,647). For example: `140,610 * 15,712 = 2,209,264,320 > 2^31-1`. This is signed integer overflow, which is undefined behavior in C++.

The same overflow occurs in `backward()` (`phasing_hmm.cpp`) where `imputeProb` is indexed via `std::copy`'s third argument:

```
    imputeProb.begin() + curr_missing_locus * C->n_states * HAP_NUMBER
```

Here the multiplication chain is `int * unsigned int * int`. The C++ arithmetic conversion rules promote the int operands to unsigned int for the first multiply (`curr_missing_locus * C->n_states`), but `HAP_NUMBER` is a `#define` expanding to the int literal 8, and the intermediate result is unsigned. However, the addition with the iterator (which uses `ptrdiff_t`, a signed type) can still produce incorrect results when the unsigned product exceeds `PTRDIFF_MAX`, and compilers may optimize assuming no signed overflow in the surrounding expressions.

The fix casts the leftmost operand in each multiplication chain to `size_t`, ensuring the entire expression is evaluated in 64-bit unsigned arithmetic. The cast is placed on the leftmost term because C++ arithmetic conversions then propagate the wider type through all subsequent multiplications in the expression:

```
  (size_t)curr_missing_locus * C->n_states * HAP_NUMBER
```

This is preferred over casting an intermediate term because it is unambiguous — every multiplication in the chain is guaranteed to be performed in `size_t`, regardless of operator associativity.

Four sites are fixed:
- phasing_hmm.h `TRANS_HAP()`: states_haps changed from int to size_t
- phasing_hmm.h `IMPUTE_FLAT_HET()`: states_haps changed from int to size_t (this was the crash site)
- phasing_hmm.cpp `backward()`: two std::copy offset expressions cast to size_t (phasingProb and imputeProb indexing)

The phasingProb offset (`curr_segment_index * n_states * HAP_NUMBER`) does not overflow with current data sizes (~5026 * 15712 = ~79M) but is fixed defensively since the same pattern applies.