### PR TITLE
Add GLIMPSE2_inspect tool for binary reference panel inspection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ rm -r htslib-1.16
 COPY chunk GLIMPSE/chunk/
 COPY common GLIMPSE/common/
 COPY concordance GLIMPSE/concordance/
+COPY inspect GLIMPSE/inspect/
 COPY ligate GLIMPSE/ligate/
 COPY phase GLIMPSE/phase/
 COPY split_reference GLIMPSE/split_reference/
@@ -53,7 +54,7 @@ RUN cd GLIMPSE && \
 make clean && \
 make system -j$(nproc)
 
-RUN mv GLIMPSE/chunk/bin/GLIMPSE2_chunk GLIMPSE/split_reference/bin/GLIMPSE2_split_reference GLIMPSE/phase/bin/GLIMPSE2_phase GLIMPSE/ligate/bin/GLIMPSE2_ligate GLIMPSE/concordance/bin/GLIMPSE2_concordance /bin && \
+RUN mv GLIMPSE/chunk/bin/GLIMPSE2_chunk GLIMPSE/split_reference/bin/GLIMPSE2_split_reference GLIMPSE/phase/bin/GLIMPSE2_phase GLIMPSE/ligate/bin/GLIMPSE2_ligate GLIMPSE/concordance/bin/GLIMPSE2_concordance GLIMPSE/inspect/bin/GLIMPSE2_inspect /bin && \
 chmod +x /bin/GLIMPSE2* && \
 rm -rf GLIMPSE
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@ layout: default
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+	* Added `GLIMPSE2_inspect` tool to print summary statistics (region, genetic-map span, haplotype count, variant-type and allele-frequency breakdowns) for a binary reference panel (`.bin`) produced by `GLIMPSE2_split_reference`.
+
 ## v2.0.0
 	* Major release. Introduced speedups and accuracy improvements. Version used for the preprint. (https://doi.org/10.1101/2022.11.28.518213)
 

--- a/docs/docs/documentation/inspect.md
+++ b/docs/docs/documentation/inspect.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: inspect
+nav_order: 6
+parent: Documentation
+---
+# inspect
+{: .no_toc .text-center }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+### Description
+Inspect a GLIMPSE2 binary reference panel (`.bin` file produced by `GLIMPSE2_split_reference`) and print summary statistics. Useful for debugging, validation, and understanding chunk characteristics.
+
+Statistics reported include:
+
+- File size, chromosome, input/output regions (bp and Mbp)
+- Genetic map span for input and output regions (cM)
+- Number of haplotypes
+- Variant counts (total, common, rare, common HQ, low quality)
+- Variant types (SNP, MNP, indel, other)
+- Allele-frequency distribution (monomorphic, singletons, MAC 2-5, MAF <1%, 1-5%, 5-50%)
+- Core (output region) vs buffer variant breakdown
+
+### Usage
+
+<div class="code-example" markdown="1">
+```bash
+GLIMPSE2_inspect --input reference_panel/split/1000GP.chr22.noNA12878_chr22_16050075_17084716.bin
+```
+</div>
+
+---
+
+### Command line options
+
+#### Basic options
+
+| Option name          | Argument| Default  | Description |
+|:---------------------|:--------|:---------|:-------------------------------------|
+| \-\-help             | NA      | NA       | Produces help message |
+
+#### Input files
+
+| Option name          | Argument| Default  | Description |
+|:---------------------|:--------|:---------|:-------------------------------------|
+| \-I \[\-\-input \]   | STRING  | NA       | Binary reference panel file (.bin) to inspect |
+
+#### Output files
+
+| Option name          | Argument| Default  | Description |
+|:---------------------|:--------|:---------|:-------------------------------------|
+| \-\-log              | STRING  | NA       | Log file  |

--- a/docs/docs/installation/compile_glimpse2.md
+++ b/docs/docs/installation/compile_glimpse2.md
@@ -41,6 +41,7 @@ You'll find there a folder containing all the software packages and other utilit
 - **concordance**: program to verify the accuracy of low-coverage imputation against high-coverage genomes
 - **docker**: all scripts needed to build a docker file comprising all binaries
 - **docs**: documentation in html
+- **inspect**: program to print summary statistics for a binary reference panel (.bin) file
 - **ligate**: ligate multiple imputed BCF/VCF files into a single chromosome-length file
 - **maps**: genetics maps in b37 and b38
 - **phase**: program to impute and phase low-coverage data.

--- a/inspect/makefile
+++ b/inspect/makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/inspect/src/containers/bitmatrix.cpp
+++ b/inspect/src/containers/bitmatrix.cpp
@@ -1,0 +1,1 @@
+../../../common/src/containers/bitmatrix.cpp

--- a/inspect/src/containers/bitmatrix.h
+++ b/inspect/src/containers/bitmatrix.h
@@ -1,0 +1,1 @@
+../../../common/src/containers/bitmatrix.h

--- a/inspect/src/containers/ref_haplotype_set.cpp
+++ b/inspect/src/containers/ref_haplotype_set.cpp
@@ -1,0 +1,1 @@
+../../../common/src/containers/ref_haplotype_set.cpp

--- a/inspect/src/containers/ref_haplotype_set.h
+++ b/inspect/src/containers/ref_haplotype_set.h
@@ -1,0 +1,1 @@
+../../../common/src/containers/ref_haplotype_set.h

--- a/inspect/src/containers/variant_map.cpp
+++ b/inspect/src/containers/variant_map.cpp
@@ -1,0 +1,1 @@
+../../../common/src/containers/variant_map.cpp

--- a/inspect/src/containers/variant_map.h
+++ b/inspect/src/containers/variant_map.h
@@ -1,0 +1,1 @@
+../../../common/src/containers/variant_map.h

--- a/inspect/src/inspect.cpp
+++ b/inspect/src/inspect.cpp
@@ -23,19 +23,12 @@
  * SOFTWARE.
  ******************************************************************************/
 
-#ifndef _VERSION_H
-#define _VERSION_H
+#define _DECLARE_TOOLBOX_HERE
+#include <inspector/inspector_header.h>
 
-#define CALL_VERSION "2.0.0"
-#define CHUNK_VERSION "2.0.0"
-#define CONCORDANCE_VERSION "2.0.0"
-#define INSPECT_VERSION "2.0.0"
-#define LIGATE_VERSION "2.0.0"
-#define PHASE_VERSION "2.0.0"
-#define SPLIT_REFERENCE_VERSION "2.0.0"
-#define SIMULATE_BAMS_VERSION "2.0.0"
-#define SAMPLE_VERSION "2.0.0"
-#define SNPARRAY_VERSION "2.0.0"
-#define STATS_VERSION "2.0.0"
-
-#endif
+int main(int argc, char ** argv) {
+	std::vector < std::string > args;
+	for (int a = 1 ; a < argc ; a ++) args.push_back(std::string(argv[a]));
+	inspector().inspect(args);
+	return EXIT_SUCCESS;
+}

--- a/inspect/src/inspector/inspector_header.h
+++ b/inspect/src/inspector/inspector_header.h
@@ -23,19 +23,34 @@
  * SOFTWARE.
  ******************************************************************************/
 
-#ifndef _VERSION_H
-#define _VERSION_H
+#ifndef _INSPECTOR_H
+#define _INSPECTOR_H
 
-#define CALL_VERSION "2.0.0"
-#define CHUNK_VERSION "2.0.0"
-#define CONCORDANCE_VERSION "2.0.0"
-#define INSPECT_VERSION "2.0.0"
-#define LIGATE_VERSION "2.0.0"
-#define PHASE_VERSION "2.0.0"
-#define SPLIT_REFERENCE_VERSION "2.0.0"
-#define SIMULATE_BAMS_VERSION "2.0.0"
-#define SAMPLE_VERSION "2.0.0"
-#define SNPARRAY_VERSION "2.0.0"
-#define STATS_VERSION "2.0.0"
+#include <utils/otools.h>
+#include <containers/ref_haplotype_set.h>
+#include <containers/variant_map.h>
+
+class inspector {
+public:
+	//COMMAND LINE OPTIONS
+	bpo::options_description descriptions;
+	bpo::variables_map options;
+
+	//DATA
+	ref_haplotype_set H;
+	variant_map V;
+
+	//CONSTRUCTOR
+	inspector();
+	~inspector();
+
+	//METHODS
+	void declare_options();
+	void parse_command_line(std::vector < std::string > &);
+	void check_options();
+	void read_binary_panel();
+	void print_statistics();
+	void inspect(std::vector < std::string > &);
+};
 
 #endif

--- a/inspect/src/inspector/inspector_management.cpp
+++ b/inspect/src/inspector/inspector_management.cpp
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (C) 2022-2023 Simone Rubinacci
+ * Copyright (C) 2022-2023 Olivier Delaneau
+ *
+ * MIT Licence
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include <inspector/inspector_header.h>
+#include <boost/archive/binary_iarchive.hpp>
+#include <htslib/vcf.h>
+#include <sys/stat.h>
+
+inspector::inspector() {
+}
+
+inspector::~inspector() {
+}
+
+void inspector::read_binary_panel() {
+	std::string filename = options["input"].as < std::string > ();
+	vrb.wait("  * Reading binary reference panel");
+	tac.clock();
+
+	std::ifstream ifs(filename, std::ios::binary | std::ios_base::in);
+	if (!ifs.good()) vrb.error("Cannot open binary reference panel file: [" + filename + "]");
+
+	try {
+		boost::archive::binary_iarchive ia(ifs);
+		ia >> H;
+		ia >> V;
+	} catch (std::exception& e) {
+		std::stringstream err_str;
+		err_str << "Problem reading binary reference panel (exception from boost archive). ";
+		err_str << "Ensure you are using the same GLIMPSE and boost library version. ";
+		err_str << e.what();
+		vrb.error(err_str.str());
+	}
+
+	if (H.Ypacked.size() == 0) vrb.error("Problem reading binary file format. Empty PBWT detected.");
+	vrb.bullet("Binary reference panel read (" + stb.str(tac.rel_time()*1.0/1000, 2) + "s)");
+}
+
+static std::string format_number(unsigned long n) {
+	std::string s = std::to_string(n);
+	int pos = s.length() - 3;
+	while (pos > 0) {
+		s.insert(pos, ",");
+		pos -= 3;
+	}
+	return s;
+}
+
+static std::string format_bp(int bp) {
+	double val = bp;
+	if (val >= 1e9) return stb.str(val / 1e9, 2) + " Gbp";
+	if (val >= 1e6) return stb.str(val / 1e6, 2) + " Mbp";
+	if (val >= 1e3) return stb.str(val / 1e3, 2) + " kbp";
+	return stb.str(bp) + " bp";
+}
+
+static std::string format_pct(unsigned long count, unsigned long total) {
+	if (total == 0) return "0.0%";
+	return stb.str(((double)count / total) * 100.0, 1) + "%";
+}
+
+void inspector::print_statistics() {
+	std::string filename = options["input"].as < std::string > ();
+
+	// File size
+	struct stat st;
+	long long file_size = 0;
+	if (stat(filename.c_str(), &st) == 0) file_size = st.st_size;
+
+	std::string size_str;
+	if (file_size >= (long long)1024*1024*1024) size_str = stb.str((double)file_size / (1024.0*1024.0*1024.0), 2) + " GB";
+	else if (file_size >= 1024*1024) size_str = stb.str((double)file_size / (1024.0*1024.0), 2) + " MB";
+	else if (file_size >= 1024) size_str = stb.str((double)file_size / 1024.0, 2) + " KB";
+	else size_str = stb.str(file_size) + " bytes";
+
+	// Region stats (coords are 1-based inclusive, per htslib region-string convention)
+	int input_span = V.input_stop - V.input_start + 1;
+	int output_span = V.output_stop - V.output_start + 1;
+
+	// Genetic map stats: scan all variants for cM range.
+	// Note: the .bin format does not record whether split_reference was given a
+	// real genetic map or fell back to the bp/1e6 synthetic map — both paths
+	// baseline-subtract the first variant's cm, so we can't distinguish here.
+	// We always print the observed cM range and let the caller interpret it.
+	double input_min_cm = std::numeric_limits<double>::max();
+	double input_max_cm = std::numeric_limits<double>::lowest();
+	double output_min_cm = std::numeric_limits<double>::max();
+	double output_max_cm = std::numeric_limits<double>::lowest();
+
+	// Variant type counts (type field uses htslib VCF_* bitmask: VCF_SNP=1, VCF_MNP=2, VCF_INDEL=4, VCF_OTHER=8, etc.)
+	unsigned long n_snps = 0, n_mnps = 0, n_indels = 0, n_other = 0;
+	unsigned long n_lq = 0;
+	unsigned long n_core = 0, n_buffer = 0;
+
+	// Allele frequency bins (based on minor allele count / frequency)
+	unsigned long af_singleton = 0;    // MAC == 1
+	unsigned long af_mac_2_5 = 0;      // MAC 2-5
+	unsigned long af_maf_lt_001 = 0;   // MAF < 0.01
+	unsigned long af_maf_001_005 = 0;  // MAF 0.01-0.05
+	unsigned long af_maf_005_050 = 0;  // MAF 0.05-0.50
+	unsigned long af_monomorphic = 0;  // MAC == 0
+
+	for (int i = 0; i < (int)V.vec_pos.size(); i++) {
+		variant * v = V.vec_pos[i];
+
+		// Genetic map
+		if (v->cm < input_min_cm) input_min_cm = v->cm;
+		if (v->cm > input_max_cm) input_max_cm = v->cm;
+		if (v->bp >= V.output_start && v->bp <= V.output_stop) {
+			if (v->cm < output_min_cm) output_min_cm = v->cm;
+			if (v->cm > output_max_cm) output_max_cm = v->cm;
+		}
+
+		// Core vs buffer
+		if (v->bp >= V.output_start && v->bp <= V.output_stop) n_core++;
+		else n_buffer++;
+
+		// Variant type (htslib bitmask)
+		if (v->type & VCF_SNP) n_snps++;
+		else if (v->type & VCF_MNP) n_mnps++;
+		else if (v->type & VCF_INDEL) n_indels++;
+		else n_other++;
+
+		// Low quality
+		if (v->LQ) n_lq++;
+
+		// Allele frequency distribution. Use the per-variant allele-number
+		// (cref + calt from the source VCF) as the denominator, so sites with
+		// missing genotypes bucket correctly.
+		unsigned int mac = v->getMAC();
+		unsigned int an = v->cref + v->calt;
+		double maf = (an > 0) ? (double)mac / an : 0.0;
+
+		if (mac == 0) af_monomorphic++;
+		else if (mac == 1) af_singleton++;
+		else if (mac <= 5) af_mac_2_5++;
+		else if (maf < 0.01) af_maf_lt_001++;
+		else if (maf < 0.05) af_maf_001_005++;
+		else af_maf_005_050++;
+	}
+
+	// Print everything
+	vrb.title("Binary reference panel summary:");
+	vrb.bullet("File                 : " + filename);
+	vrb.bullet("File size            : " + size_str);
+	vrb.bullet("Chromosome           : " + V.chrid);
+	vrb.print("");
+
+	vrb.bullet("Input region         : " + V.input_gregion + " (" + format_bp(input_span) + ")");
+	vrb.bullet("Output region        : " + V.output_gregion + " (" + format_bp(output_span) + ")");
+
+	if (input_min_cm <= input_max_cm)
+		vrb.bullet("Genetic map (input)  : " + stb.str(input_min_cm, 4) + " - " + stb.str(input_max_cm, 4) + " cM (" + stb.str(input_max_cm - input_min_cm, 4) + " cM span)");
+	if (output_min_cm <= output_max_cm)
+		vrb.bullet("Genetic map (output) : " + stb.str(output_min_cm, 4) + " - " + stb.str(output_max_cm, 4) + " cM (" + stb.str(output_max_cm - output_min_cm, 4) + " cM span)");
+
+	vrb.print("");
+	vrb.bullet("Haplotypes           : " + format_number(H.n_ref_haps));
+	vrb.bullet("Variants (total)     : " + format_number(H.n_tot_sites));
+	vrb.bullet("  Common             : " + format_number(H.n_com_sites) + " (" + format_pct(H.n_com_sites, H.n_tot_sites) + ")");
+	vrb.bullet("  Rare               : " + format_number(H.n_rar_sites) + " (" + format_pct(H.n_rar_sites, H.n_tot_sites) + ")");
+	vrb.bullet("  Common HQ          : " + format_number(H.n_com_sites_hq) + " (" + format_pct(H.n_com_sites_hq, H.n_tot_sites) + ")");
+	vrb.bullet("  Low quality        : " + format_number(n_lq) + " (" + format_pct(n_lq, H.n_tot_sites) + ")");
+
+	vrb.print("");
+	vrb.bullet("Variant types:");
+	vrb.bullet("  SNPs               : " + format_number(n_snps) + " (" + format_pct(n_snps, H.n_tot_sites) + ")");
+	if (n_mnps > 0)
+		vrb.bullet("  MNPs               : " + format_number(n_mnps) + " (" + format_pct(n_mnps, H.n_tot_sites) + ")");
+	vrb.bullet("  Indels             : " + format_number(n_indels) + " (" + format_pct(n_indels, H.n_tot_sites) + ")");
+	if (n_other > 0)
+		vrb.bullet("  Other              : " + format_number(n_other) + " (" + format_pct(n_other, H.n_tot_sites) + ")");
+
+	vrb.print("");
+	vrb.bullet("Allele frequency distribution:");
+	if (af_monomorphic > 0)
+		vrb.bullet("  Monomorphic        : " + format_number(af_monomorphic) + " (" + format_pct(af_monomorphic, H.n_tot_sites) + ")");
+	vrb.bullet("  Singletons         : " + format_number(af_singleton) + " (" + format_pct(af_singleton, H.n_tot_sites) + ")");
+	vrb.bullet("  MAC 2-5            : " + format_number(af_mac_2_5) + " (" + format_pct(af_mac_2_5, H.n_tot_sites) + ")");
+	vrb.bullet("  MAF < 1%           : " + format_number(af_maf_lt_001) + " (" + format_pct(af_maf_lt_001, H.n_tot_sites) + ")");
+	vrb.bullet("  MAF 1-5%           : " + format_number(af_maf_001_005) + " (" + format_pct(af_maf_001_005, H.n_tot_sites) + ")");
+	vrb.bullet("  MAF 5-50%          : " + format_number(af_maf_005_050) + " (" + format_pct(af_maf_005_050, H.n_tot_sites) + ")");
+
+	vrb.print("");
+	vrb.bullet("Region breakdown:");
+	vrb.bullet("  Core (output)      : " + format_number(n_core) + " variants");
+	vrb.bullet("  Buffer only        : " + format_number(n_buffer) + " variants");
+}
+
+void inspector::inspect(std::vector < std::string > & args) {
+	declare_options();
+	parse_command_line(args);
+	check_options();
+	read_binary_panel();
+	print_statistics();
+}

--- a/inspect/src/inspector/inspector_parameters.cpp
+++ b/inspect/src/inspector/inspector_parameters.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (C) 2022-2023 Simone Rubinacci
+ * Copyright (C) 2022-2023 Olivier Delaneau
+ *
+ * MIT Licence
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+
+#include "../../versions/versions.h"
+#include <inspector/inspector_header.h>
+
+void inspector::declare_options() {
+	bpo::options_description opt_base ("Basic options");
+	opt_base.add_options()
+			("help", "Produces help message");
+
+	bpo::options_description opt_input ("Input parameters");
+	opt_input.add_options()
+			("input,I", bpo::value< std::string >(), "Binary reference panel file (.bin) to inspect");
+
+	bpo::options_description opt_output ("Output files");
+	opt_output.add_options()
+			("log", bpo::value< std::string >(), "Log file");
+
+	descriptions.add(opt_base).add(opt_input).add(opt_output);
+}
+
+void inspector::parse_command_line(std::vector < std::string > & args) {
+	try {
+		bpo::store(bpo::command_line_parser(args).options(descriptions).run(), options);
+		bpo::notify(options);
+	} catch ( const boost::program_options::error& e ) { std::cerr << "Error parsing command line arguments: " << std::string(e.what()) << std::endl; exit(1); }
+
+	if (options.count("log") && !vrb.open_log(options["log"].as < std::string > ()))
+		vrb.error("Impossible to create log file [" + options["log"].as < std::string > () +"]");
+
+	vrb.title("[GLIMPSE2] Inspect binary reference panel");
+	vrb.bullet("Authors              : Simone RUBINACCI & Olivier DELANEAU, University of Lausanne");
+	vrb.bullet("Contact              : simone.rubinacci@unil.ch & olivier.delaneau@unil.ch");
+	vrb.bullet("Version              : GLIMPSE2_inspect v" + std::string(INSPECT_VERSION) + " / commit = " + std::string(__COMMIT_ID__) + " / release = " + std::string (__COMMIT_DATE__));
+	vrb.bullet("Citation             : BiorXiv, (2022). DOI: https://doi.org/10.1101/2022.11.28.518213");
+	vrb.bullet("                     : Nature Genetics 53, 120-126 (2021). DOI: https://doi.org/10.1038/s41588-020-00756-0");
+	vrb.bullet("Run date             : " + tac.date());
+
+	if (options.count("help")) { std::cout << descriptions << std::endl; exit(0); }
+}
+
+void inspector::check_options() {
+	if (!options.count("input"))
+		vrb.error("You must specify --input / -I");
+}

--- a/inspect/src/io/gmap_reader.cpp
+++ b/inspect/src/io/gmap_reader.cpp
@@ -1,0 +1,1 @@
+../../../common/src/io/gmap_reader.cpp

--- a/inspect/src/io/gmap_reader.h
+++ b/inspect/src/io/gmap_reader.h
@@ -1,0 +1,1 @@
+../../../common/src/io/gmap_reader.h

--- a/inspect/src/objects/genotype.cpp
+++ b/inspect/src/objects/genotype.cpp
@@ -1,0 +1,1 @@
+../../../common/src/objects/genotype.cpp

--- a/inspect/src/objects/genotype.h
+++ b/inspect/src/objects/genotype.h
@@ -1,0 +1,1 @@
+../../../common/src/objects/genotype.h

--- a/inspect/src/objects/variant.cpp
+++ b/inspect/src/objects/variant.cpp
@@ -1,0 +1,1 @@
+../../../common/src/objects/variant.cpp

--- a/inspect/src/objects/variant.h
+++ b/inspect/src/objects/variant.h
@@ -1,0 +1,1 @@
+../../../common/src/objects/variant.h

--- a/inspect/src/utils/basic_algos.h
+++ b/inspect/src/utils/basic_algos.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/basic_algos.h

--- a/inspect/src/utils/basic_stats.h
+++ b/inspect/src/utils/basic_stats.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/basic_stats.h

--- a/inspect/src/utils/checksum_utils.h
+++ b/inspect/src/utils/checksum_utils.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/checksum_utils.h

--- a/inspect/src/utils/compressed_io.h
+++ b/inspect/src/utils/compressed_io.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/compressed_io.h

--- a/inspect/src/utils/otools.h
+++ b/inspect/src/utils/otools.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/otools.h

--- a/inspect/src/utils/random_number.h
+++ b/inspect/src/utils/random_number.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/random_number.h

--- a/inspect/src/utils/string_utils.h
+++ b/inspect/src/utils/string_utils.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/string_utils.h

--- a/inspect/src/utils/timer.h
+++ b/inspect/src/utils/timer.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/timer.h

--- a/inspect/src/utils/verbose.h
+++ b/inspect/src/utils/verbose.h
@@ -1,0 +1,1 @@
+../../../common/src/utils/verbose.h

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-projects = chunk concordance ligate phase split_reference
+projects = chunk concordance inspect ligate phase split_reference
 
 .PHONY: all $(projects) system clean
 


### PR DESCRIPTION
@srubinacci one more PR here for a new tool to inspect the binary reference panel files.  I find this very useful when trying to debug things (errors, but also variance in runtime and memory usage).  I've done my best to match existing style and conventions, and have included updates to the docs and Dockerfile.

It's not a ton of code, so hopefully not too burdensome to review.  If you think this is a useful addition, I'd be **very** open to suggestions if you think there's other output that would be useful, or other breakdowns, etc.

Statistics reported:
- File size, chromosome, input/output regions (bp and Mbp)
- Genetic map span for input and output regions (cM)
- Haplotype count
- Variant counts: total, common, rare, common HQ, low quality
- Variant types: SNP, MNP, indel, other (using htslib VCF_* bitmask)
- Allele frequency distribution: monomorphic, singletons, MAC 2-5, and MAF bins (<1%, 1-5%, 5-50%)
- Core (output region) vs buffer variant breakdown

Usage: GLIMPSE2_inspect -I panel.bin

*Example Output:*

```
[GLIMPSE2] Inspect binary reference panel
  * Authors              : Simone RUBINACCI & Olivier DELANEAU, University of Lausanne
  * Contact              : simone.rubinacci@unil.ch & olivier.delaneau@unil.ch
  * Version              : GLIMPSE2_inspect v2.0.0 / commit = a095cfd / release = 2026-04-17
  * Citation             : BiorXiv, (2022). DOI: https://doi.org/10.1101/2022.11.28.518213
  *                      : Nature Genetics 53, 120-126 (2021). DOI: https://doi.org/10.1038/s41588-020-00756-0
  * Run date             : 17/04/2026 - 06:40:23
  * Binary reference panel read (0.23s)

Binary reference panel summary:
  * File                 : autosome_chrD3_34907769_46737256.bin
  * File size            : 162.08 MB
  * Chromosome           : chrD3

  * Input region         : chrD3:34907769-46737256 (11.83 Mbp)
  * Output region        : chrD3:35407768-43979210 (8.57 Mbp)
  * Genetic map (input)  : 0.0000 - 27.8580 cM (27.8580 cM span)
  * Genetic map (output) : 1.4474 - 26.8580 cM (25.4106 cM span)

  * Haplotypes           : 1,984
  * Variants (total)     : 505,119
  *   Common             : 505,119 (100.0%)
  *   Rare               : 0 (0.0%)
  *   Common HQ          : 421,621 (83.5%)
  *   Low quality        : 83,498 (16.5%)

  * Variant types:
  *   SNPs               : 431,206 (85.4%)
  *   Indels             : 73,913 (14.6%)

  * Allele frequency distribution:
  *   Singletons         : 18 (0.0%)
  *   MAC 2-5            : 92,074 (18.2%)
  *   MAF < 1%           : 200,226 (39.6%)
  *   MAF 1-5%           : 85,782 (17.0%)
  *   MAF 5-50%          : 127,019 (25.1%)

  * Region breakdown:
  *   Core (output)      : 378,201 variants
  *   Buffer only        : 126,918 variants
```