### PR TITLE
Optimize compactSelection: 25-50% wall-time reduction in GLIMPSE2_phase, byte-identical results

### DIFF
--- a/common/src/containers/bitmatrix.h
+++ b/common/src/containers/bitmatrix.h
@@ -54,6 +54,7 @@ public:
 	void set(unsigned int row, unsigned char bit);
 	unsigned char get(unsigned int row, unsigned int col) const;
 	unsigned char getByte(unsigned int row, unsigned int col) const;
+	void setByte(unsigned int row, unsigned int col, unsigned char byte);
 
 	void transpose(bitmatrix & BM, unsigned int _min_row, unsigned int _min_col, unsigned int _max_row, unsigned int _max_col);
 	void transpose(bitmatrix & BM, unsigned int _max_row, unsigned int _max_col);
@@ -107,6 +108,14 @@ unsigned char bitmatrix::get(unsigned int row, unsigned int col) const {
 inline
 unsigned char bitmatrix::getByte(unsigned int row, unsigned int col) const {
 	return bytes[((unsigned long)row) * (n_cols>>3) +  (col>>3)];
+}
+
+//Writes 8 packed bits at column col (must be a multiple of 8). Avoids the
+//read-modify-write of set() when all 8 bits in the byte are known up front.
+inline
+void bitmatrix::setByte(unsigned int row, unsigned int col, unsigned char byte) {
+	assert((col & 7) == 0);
+	bytes[((unsigned long)row) * (n_cols>>3) +  (col>>3)] = byte;
 }
 
 #endif

--- a/phase/src/containers/conditioning_set.cpp
+++ b/phase/src/containers/conditioning_set.cpp
@@ -37,7 +37,9 @@ conditioning_set::conditioning_set(const variant_map & _mapG, const haplotype_se
 		ee_phs(1.0 -_err_phs),
 		ed_imp(_err_imp),
 		ee_imp(1.0 - _err_imp),
-		Kinit(_kinit), Kpbwt(_kpbwt)
+		Kinit(_kinit), Kpbwt(_kpbwt),
+		cached_full_panel_n(0),
+		transitions_valid(false)
 {
 	var_type = std::vector < unsigned char > (n_tot_sites);
 	major_alleles = H.major_alleles;
@@ -102,9 +104,12 @@ void conditioning_set::compactSelection(const int ind, const int iter)
 	}
 	else if (Kpbwt >= H.n_ref_haps)
 	{
+		use_list = false;
+		//Cache hit: the full-panel selection produces the same derived state every
+		//time, so reuse the result of the previous build (see header for details).
+		if (cached_full_panel_n == H.n_ref_haps) return;
 		idxHaps_ref.resize(H.n_ref_haps);
 		std::iota(idxHaps_ref.begin(), idxHaps_ref.end(), 0);
-		use_list = false;
 	}
 	//Kpbwt == 0 easy: just go here..
 	if (use_list && (H.list_states[hapid].size() > 0 || H.list_states[hapid+ploidyM1].size() > 0))
@@ -169,11 +174,17 @@ void conditioning_set::compactSelection(const int ind, const int iter)
 			lrel++;
 		} //else mono: do nothing
 	}
+
+	//We just rebuilt polymorphic_sites, so any previously computed t/nt are stale.
+	//Mark the full-panel cache as valid only if we actually took that path.
+	transitions_valid = false;
+	cached_full_panel_n = use_list ? 0 : H.n_ref_haps;
 }
 
 void conditioning_set::updateTransitions()
 {
 	if (polymorphic_sites.size() == 0) return;
+	if (transitions_valid) return;
 	t.resize(polymorphic_sites.size() - 1);
 	nt.resize(polymorphic_sites.size() - 1);
 	for (int l = 1 ; l < polymorphic_sites.size() ; l ++)
@@ -181,4 +192,5 @@ void conditioning_set::updateTransitions()
 		t[l-1] = std::clamp(-expm1(nrho * (mapG.vec_pos[polymorphic_sites[l]]->cm - mapG.vec_pos[polymorphic_sites[l-1]]->cm)), 1e-7, one_l);
 		nt[l-1] = 1.0f-t[l-1];
 	}
+	transitions_valid = true;
 }

--- a/phase/src/containers/conditioning_set.cpp
+++ b/phase/src/containers/conditioning_set.cpp
@@ -139,9 +139,28 @@ void conditioning_set::compactSelection(const int ind, const int iter)
 
 	//Build bitmatrix Hvar
 	Hvar.reallocate(polymorphic_sites.size(), n_states);
+	//Pack 8 selected reference bits per byte and write whole bytes (rather than 8
+	//read-modify-write set() calls per byte). Profiling showed this loop dominated
+	//runtime at ~35% of the cycles. The trailing bits when n_states is not a multiple
+	//of 8 still go through set() to preserve any pre-existing content in the row's
+	//last byte. Bit ordering matches set(): col 0 -> MSB ... col 7 -> LSB.
+	const int n_states_full = (n_states / 8) * 8;
 	for (int labs = 0, lrel = 0, lcom = 0 ; labs < n_tot_sites ; labs ++) {
 		if (var_type[labs] == TYPE_COMMON) {
-			for (int k = 0 ; k < idxHaps_ref.size() ; k++) Hvar.set(lrel, k, H.HvarRef.get(lcom, idxHaps_ref[k]));
+			for (int k = 0 ; k < n_states_full ; k += 8) {
+				const unsigned char b =
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+0]) << 7) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+1]) << 6) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+2]) << 5) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+3]) << 4) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+4]) << 3) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+5]) << 2) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+6]) << 1) |
+					((unsigned char)H.HvarRef.get(lcom, idxHaps_ref[k+7]) << 0);
+				Hvar.setByte(lrel, k, b);
+			}
+			for (int k = n_states_full ; k < n_states ; k++)
+				Hvar.set(lrel, k, H.HvarRef.get(lcom, idxHaps_ref[k]));
 			lrel++;
 			lcom++;
 		} else if (var_type[labs] == TYPE_RARE) {

--- a/phase/src/containers/conditioning_set.h
+++ b/phase/src/containers/conditioning_set.h
@@ -78,10 +78,18 @@ public:
 	std::vector<unsigned int> swap_ref;
 	std::vector<unsigned int> swap_tar;
 
+	//FULL-PANEL CACHE
+	//When Kpbwt >= n_ref_haps the iota selection path runs and the derived state
+	//(var_type, polymorphic_sites, monomorphic_sites, Svar, Hvar, t, nt) depends only
+	//on H, so it is identical across individuals and iterations. Assumes H is
+	//immutable for the lifetime of this object (true today).
+	unsigned int cached_full_panel_n;		//0 when invalid; otherwise H.n_ref_haps it was built for
+	bool transitions_valid;					//true when t and nt match the current polymorphic_sites
+
 	//CONSTRUCTOR/DESTRUCTOR/INITIALIZATION
 	conditioning_set(const variant_map &, const haplotype_set &, const unsigned int, const unsigned int, const int,const int, const float, const float, const bool );
 	~conditioning_set();
-	void clear();
+	void clear();		//currently unimplemented; if defined, must reset cached_full_panel_n=0 and transitions_valid=false
 
 	//SELECTION ROUTINES
 	void compactSelection(const int ind, const int iter);

--- a/phase/src/models/phasing_hmm.cpp
+++ b/phase/src/models/phasing_hmm.cpp
@@ -133,10 +133,10 @@ void phasing_hmm::reallocate(const std::vector < bool > & H0, const std::vector 
 	imputeProbSumSum.resize(n_miss);
 	imputeProbOf1s.resize(n_miss * HAP_NUMBER);
 
-	std::fill(phasingProb.begin(), phasingProb.end(), 0.0f);
-	std::fill(phasingProbSum.begin(), phasingProbSum.end(), 0.0f);
-	std::fill(imputeProb.begin(), imputeProb.end(), 0.0f);
-	std::fill(imputeProbSum.begin(), imputeProbSum.end(), 0.0f);
+	//phasingProb, phasingProbSum, imputeProb and imputeProbSum are fully overwritten
+	//by std::copy from prob/probSumH inside backward() before forward()/IMPUTE_FLAT_HET()
+	//ever read them, so the explicit zeroing here is dead work and was a measurable
+	//memset/memmove cost in profiling.
 }
 
 void phasing_hmm::forward()


### PR DESCRIPTION
## Preamble

The changes in this PR yield real and substantial savings in GLIMPSE2_phase runtimes in my hands, on the order of 25-50% reduction in runtime.  I've done my best to benchmark what I think are representative uses of GLIMPSE2_phase, but I'm also aware that the range of panels sizes and compositions, and phasing settings are likely significantly broader than I've tested.  

These changes have been tested and shown to yield similar reductions in runtime on the following samples:

- The example 1000G data in the tutorial
- a ~2X coverage sample with a ~1950 hap panel, with -Kpbwt at 2000, and again at 1900
- a ~0.2X coverage sample with a ~1950 hap panel, with -Kpbwt at 2000, and again at 1900

## Summary

`conditioning_set::compactSelection` was the single biggest hotspot in `GLIMPSE2_phase` on the workloads I profiled — about **35% of wall-time on x86** and **about 25% on arm64** (where simde halves the AVX2 throughput, inflating the relative cost of the surrounding HMM kernels). This PR introduces two small, isolated changes to `compactSelection` plus one trivial dead-code removal. End-to-end wall-time drops by **25-50%** depending on coverage, panel size, and `--Kpbwt`. Output is byte-identical to `master` across every workload I tested.

## What this is, and what it is *not*

This PR **does not** touch any HMM kernel, any floating-point operation, any emission/transition computation, or any RNG draw. The output is determined entirely by the HMM kernels and those are byte-identical. The only changes are:

- avoiding 8 byte read-modify-writes per output byte when constructing the `Hvar` bitmatrix, by writing 8 packed bits at once;
- skipping a fully-redundant rebuild of `compactSelection`'s output when the conditioning set is the entire reference panel (the iota path that fires by default whenever `--Kpbwt >= n_ref_haps`);
- removing four `std::fill(...,0.0f)` calls in `phasing_hmm::reallocate` whose targets are unconditionally overwritten by `std::copy` before they are ever read.

## The three commits

**1. `Pack 8 bits per byte when building Hvar in compactSelection`**

The hot inner loop was:
```cpp
for (int k = 0; k < idxHaps_ref.size(); k++)
    Hvar.set(lrel, k, H.HvarRef.get(lcom, idxHaps_ref[k]));
```
Each `set()` is a read-modify-write on a single byte, so we do 8 RMW ops per output byte (~860M byte ops per call on a typical chunk). Replacing this with 8 reads + 1 byte store via a new `bitmatrix::setByte` helper produces the same bit pattern with a single cache-friendly write. Trailing bits when `n_states` is not a multiple of 8 still go through `set()` so any pre-existing content in unused tail bits of the row's last byte is left untouched.

**2. `Cache compactSelection result for the full-panel selection path`**

When `--Kpbwt >= n_ref_haps`, `idxHaps_ref` ends up as `iota(0, n_ref_haps)` *every* burn/main iteration. The derived state (`var_type`, `polymorphic_sites`, `monomorphic_sites`, `Svar`, `Hvar`, `t`, `nt`) depends only on the reference panel — not on the individual or the iteration. The code currently rebuilds all of it on every call (~21 calls per chunk for the default 5+15 burn/main settings).

This commit caches the result, keyed on `n_ref_haps`. The cache is invalidated whenever any non-iota selection path runs (`STAGE_INIT` with `Kinit > 0`, `STAGE_RESTRICT`, the PBWT subset path, or the `list_states` post-processing). When `--Kpbwt < n_ref_haps`, the cache is never populated and the only overhead is one integer compare and one bool check per call.

The cache **assumes `H` is immutable for the lifetime of this `conditioning_set`**, which holds today — each worker thread gets a `conditioning_set` allocated once and never reseated to a different panel. I documented this invariant in the header.

**3. `Remove dead zero-fills in phasing_hmm::reallocate`**

`phasingProb`, `phasingProbSum`, `imputeProb`, and `imputeProbSum` are each fully overwritten by `std::copy` from `prob`/`probSumH` inside `backward()` before `forward()` (or `IMPUTE_FLAT_HET()`) reads them. The four `std::fill` calls were dead. Trivial.

## Performance

All numbers are wall-time on a single chunk, single thread, end-to-end (binary entry to exit). Verified byte-identical via `bcftools view -H | md5sum` on every chunk listed.

### Cat genome reference panel (Nrh=1984, L=434360 sites), single individual

| Workload | Master | Branch | Reduction |
|---|---|---|---|
| 1.9x BAM, --Kpbwt 2000 (default), 5 chunks mean | x86: 130s &nbsp;&nbsp; arm64: 140s | x86: 84s &nbsp;&nbsp; arm64: 66s | x86 ~35% &nbsp;&nbsp; arm64 ~53% |
| 0.2x BAM, --Kpbwt 2000, chrA1 | x86: 105s | x86: 58s | **x86 ~45%** |
| 1.9x BAM, --Kpbwt 1900 (PBWT subset), chrA1 | x86: 74s &nbsp;&nbsp; arm64: 78s | x86: 54s &nbsp;&nbsp; arm64: 41s | x86 ~27% &nbsp;&nbsp; arm64 ~47% |

### GLIMPSE2 tutorial (NA12878 1x, 1000GP-no-NA12878, 16 chr22 chunks)

This is the public dataset under `tutorial/`. All 16 chunks PASS `bcftools view -H | md5sum` byte-identity.

| | Master | Branch | Reduction |
|---|---|---|---|
| arm64, full step5 (16 chunks) | 278s | 184s | **33.8%** |

The 1000GP-vs-cat gap (33.8% vs ~53% on arm64) is because `--Kpbwt 2000` < `Nrh=5006` for the 1000GP panel, so the cache (commit 2) never fires; only the bit-pack (commit 1) is active. 

### Profile shape (chrA1, x86, default --Kpbwt 2000)

| Function | Master | After this PR |
|---|---|---|
| `conditioning_set::compactSelection` | **34.9%** | 1.0% |
| `imputation_hmm::backward` | 18.0% | 27.4% |
| `phasing_hmm::forward` | 17.6% | 27.2% |
| `phasing_hmm::backward` | 14.4% | 21.8% |
| `imputation_hmm::forward` | 9.6% | 14.5% |

`compactSelection` is effectively eliminated. What remains is genuine HMM compute that is already heavily SIMD-optimized.

## Caveats and notes

- **`--Kpbwt < n_ref_haps`**: commit 2's cache never fires; commit 1 still does. Speedup drops to ~25-30% on x86. No functional change.
- **`conditioning_set::clear()` is declared but has no implementation anywhere in the tree** (pre-existing). I did not add one. If this method is ever defined and used to reset the object for reuse, it must reset `cached_full_panel_n = 0` and `transitions_valid = false`. This is documented in a comment on the declaration.
- **No new unit tests**, in keeping with the project's existing test approach (end-to-end tutorial scripts as ground truth). The byte-identity check via `bcftools view -H | md5sum` is the validation I relied on.
- **Builds clean** on Linux/x86_64 (gcc 11, native AVX2) and macOS/arm64 (clang, NEON via simde).