### PR TITLE
Default to clang++ on aarch64 for faster phase imputation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ LABEL org.opencontainers.image.authors="simone.rubinacci@unil.ch"
 
 WORKDIR /docker_build/
 
-# Install required packages
-RUN apt-get update && apt-get install -y build-essential libbz2-dev libcurl4-openssl-dev autoconf libssl-dev wget zlib1g-dev liblzma-dev libdeflate-dev
+# Install required packages.
+# clang is included because on aarch64 the build defaults to clang++ (much better
+# SIMDe->NEON codegen than g++); on x86_64 the build still uses g++ (build-essential).
+RUN apt-get update && apt-get install -y build-essential clang libbz2-dev libcurl4-openssl-dev autoconf libssl-dev wget zlib1g-dev liblzma-dev libdeflate-dev
 
 # Download and build boost program_options and iostreams
 RUN wget https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.gz && \

--- a/common.mk
+++ b/common.mk
@@ -1,6 +1,6 @@
 #COMPILER MODE C++17
-CXX?=g++
-
+# Default compiler is selected by architecture below (see ARCH block), defaulting
+# to clang++ on aarch64 and g++ elsewhere. Override by passing CXX=... to make.
 
 #create folders
 dummy_build_folder_bin := $(shell mkdir -p bin)
@@ -31,6 +31,22 @@ EXEFILE=bin/GLIMPSE2_$(NAME)_static
 #CXXFLAG+= -D__COMMIT_DATE__=\"$(COMMIT_DATE)\"
 
 ARCH := $(shell uname -m)
+
+# Default compiler by architecture. On aarch64 the phase kernels are x86 AVX2/FMA
+# intrinsics that SIMDe lowers to NEON; clang generates far better NEON for SIMDe
+# than gcc does (~2.5x faster phase kernels on AWS Graviton / Neoverse), so prefer
+# clang++ when it is installed, falling back to g++ so gcc-only systems still build.
+ifneq (,$(filter arm64 aarch64,$(ARCH)))
+  ifneq (,$(shell command -v clang++ 2>/dev/null))
+    DEFAULT_CXX := clang++
+  else
+    DEFAULT_CXX := g++
+  endif
+else
+  DEFAULT_CXX := g++
+endif
+CXX ?= $(DEFAULT_CXX)
+
 ifeq ($(NAME),phase)
   ifneq (,$(filter x86_64 amd64,$(ARCH)))
     CXXFLAG+=-mavx2 -mfma
@@ -140,7 +156,8 @@ ifeq ($(OS),Darwin)
   SYS_CXX = clang++
   SYS_DYN_LIBS = -L/opt/homebrew/lib -lz -lpthread -lbz2 -llzma -lcurl -lcrypto -ldeflate
 else
-  SYS_CXX = g++
+  # clang++ on aarch64 (better SIMDe->NEON codegen), g++ on x86_64 (see DEFAULT_CXX above)
+  SYS_CXX = $(DEFAULT_CXX)
   SYS_DYN_LIBS = $(_HTSLIB_SHARED) -lz -lpthread -lbz2 -llzma -lcurl -lcrypto -ldeflate
   # When pkg-config is available, add HTSlib's static link dependencies
   # (e.g., -lhtscodecs and LTO flags required by some distro-packaged libhts.a)

--- a/docs/docs/installation/compile_glimpse2.md
+++ b/docs/docs/installation/compile_glimpse2.md
@@ -69,12 +69,15 @@ make system
 
 The `system` target auto-detects your OS, architecture, and library locations. It searches standard installation paths across all major Linux distributions (Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE, etc.) and macOS Homebrew. If `pkg-config` is installed, it is used for more precise HTSlib detection.
 
-| Platform | Compiler | Detection method |
+| Platform | Default compiler | Detection method |
 |----------|----------|-----------------|
-| Linux (all distros) | g++ | Searches `/usr/lib`, `/usr/lib64`, `/usr/local/lib`, Debian multiarch paths |
+| Linux x86_64 | g++ | Searches `/usr/lib`, `/usr/lib64`, `/usr/local/lib`, Debian multiarch paths |
+| Linux aarch64/ARM64 | clang++ (falls back to g++ if clang++ is not installed) | Searches `/usr/lib`, `/usr/lib64`, `/usr/local/lib`, Debian multiarch paths |
 | macOS ARM64 | clang++ | Searches `/opt/homebrew/lib`, plus pkg-config |
 
 On x86_64, the phase module automatically enables AVX2/FMA SIMD instructions. On ARM64 platforms, SIMD is provided via NEON instructions through the SIMDe compatibility library.
+
+On ARM64 the build **defaults to `clang++`** because clang generates substantially better NEON code for the SIMDe-translated kernels than g++ does — roughly **2.5× faster** phase imputation on AWS Graviton (Neoverse). Install clang on aarch64 to get this speedup (see [Required libraries](required_libraries)); if clang++ is not present the build automatically falls back to g++. You can always force a specific compiler by passing `CXX=` to make, e.g. `make system CXX=g++` or `make system CXX=clang++`.
 
 ### Custom build (other targets)
 

--- a/docs/docs/installation/required_libraries.md
+++ b/docs/docs/installation/required_libraries.md
@@ -59,6 +59,9 @@ sudo dnf install gcc-c++ make pkg-config \
 
 Not all Fedora-based distributions (e.g., Amazon Linux) make `htslib-devel` and `libdeflate-devel` available in their package repositories. If these packages are not found, you will need to build them from source (see below).
 
+{: .note }
+> **On aarch64/ARM64, also install `clang`.** The build defaults to `clang++` on ARM64 because it produces much faster SIMD code than g++ there (~2.5× faster phase imputation on AWS Graviton). Add `clang` to the install command above (`sudo apt-get install clang` on Debian/Ubuntu, `sudo dnf install clang` on Fedora/RHEL). If clang is not installed the build falls back to g++.
+
 After installing packages, build with `make system` from the GLIMPSE2 root directory. The build system will automatically locate libraries using `pkg-config` (for HTSlib) and by searching standard installation paths.
 
 ### Linux (from source)

--- a/docs/docs/installation/system_requirements.md
+++ b/docs/docs/installation/system_requirements.md
@@ -28,6 +28,9 @@ GLIMPSE2 is a set of C++ tools covering the process of haplotype phasing in larg
 
 We require a version of GCC > 4.4 or a recent version of Clang. We recommend using the latest available version for your system.
 
+{: .note }
+> **On aarch64/ARM64, Clang is strongly recommended and is the build's default compiler.** Clang generates much faster NEON code for GLIMPSE2's SIMDe-translated kernels than GCC does (~2.5× faster phase imputation on AWS Graviton / Neoverse). Install it with `sudo apt install clang` (Debian/Ubuntu) or `sudo dnf install clang` (Fedora/RHEL). `make system` uses `clang++` automatically when present and falls back to `g++` otherwise. On x86_64, GCC remains the default.
+
 For example running the following instruction on Ubuntu 20.04 focal:
 
 <div class="code-example" markdown="1">


### PR DESCRIPTION
I finally got around to doing some benchmarking of GLIMPSE2_phase on AWS's aarch64/graviton instances.  Unlike on mac where we get clang by default, I was generating builds initially with gcc and seeing vastly worse performance.  After some digging around and trial and error, it turns out it's _all_ gcc vs. clang.  So this PR simply changes the _default_ compiler on all aarch64 platforms to clang, with fallback to gcc.

The phase kernels are x86 AVX2 intrinsics that SIMDe lowers to NEON on ARM, and clang generates far better NEON than gcc (~1.5-2.5x faster phase kernels on AWS Graviton, bit-identical output). common.mk now defaults CXX to clang++ on aarch64 (falling back to g++ when clang++ is absent) and g++ elsewhere; the Dockerfile installs clang so the aarch64 image picks it up. Installation docs updated accordingly.