### PR TITLE
Add --compression-level option for VCF/BCF output

### DIFF
--- a/concordance/src/checker/checker_parameters.cpp
+++ b/concordance/src/checker/checker_parameters.cpp
@@ -60,6 +60,7 @@ void checker::declare_options() {
 	bpo::options_description opt_output ("Output files");
 	opt_output.add_options()
 			("output,O", bpo::value< std::string >(), "Prefix of the output files (extensions are automatically added)")
+			("compression-level", bpo::value< int >()->default_value(6), "Compression level for the BCF output produced by --out-rej-sites/--out-conc-sites/--out-disc-sites: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 produces uncompressed BCF.")
 			("log", bpo::value< std::string >(), "Log file");
 
 	descriptions.add(opt_base).add(opt_input).add(opt_algo).add(opt_output);
@@ -97,6 +98,9 @@ void checker::check_options() {
 
 	if (options["threads"].as < int > () < 1)
 		vrb.error("Number of threads is a strictly positive number.");
+
+	if (options["compression-level"].as < int > () < 0 || options["compression-level"].as < int > () > 9)
+		vrb.error("Compression level must be between 0 and 9.");
 
 	//if (options.count("min-tar-gp") &&  options.count("gt-tar"))
 	//	vrb.error("Options --gt-tar and --min-tar-gp cannot be used together.");
@@ -171,4 +175,6 @@ void checker::verbose_options() {
 	vrb.bullet("Output rej. sites : " + no_yes[options.count("out-rej-sites")]);
 	vrb.bullet("Output conc sites : " + no_yes[options.count("out-conc-sites")]);
 	vrb.bullet("Output disc sites : " + no_yes[options.count("out-disc-sites")]);
+	if (options.count("out-rej-sites") || options.count("out-conc-sites") || options.count("out-disc-sites"))
+		vrb.bullet("BCF compression   : level " + stb.str(options["compression-level"].as < int > ()));
 }

--- a/concordance/src/containers/call_set_reading.cpp
+++ b/concordance/src/containers/call_set_reading.cpp
@@ -390,7 +390,7 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 		if (out_rej_sites)
 		{
 			std::string out_filename_full = out_filename + "_rej_sites.bcf";
-			std::string out_file_format = "wb";
+			std::string out_file_format = "wb" + std::to_string(options["compression-level"].as < int > ());
 			out_fp_rej_sites = hts_open(out_filename_full.c_str(),out_file_format.c_str());
 			if (nthreads > 1) hts_set_threads(out_fp_rej_sites, nthreads);
 			out_hdr_rej_sites = bcf_hdr_dup(sr->readers[2].header);
@@ -399,7 +399,7 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 		if (out_conc_sites)
 		{
 			std::string out_filename_full = out_filename + "_conc_sites.bcf";
-			std::string out_file_format = "wb";
+			std::string out_file_format = "wb" + std::to_string(options["compression-level"].as < int > ());
 			out_fp_conc_sites = hts_open(out_filename_full.c_str(),out_file_format.c_str());
 			if (nthreads > 1) hts_set_threads(out_fp_conc_sites, nthreads);
 			out_hdr_conc_sites = bcf_hdr_dup(sr->readers[2].header);
@@ -408,7 +408,7 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 		if (out_disc_sites)
 		{
 			std::string out_filename_full = out_filename + "_disc_sites.bcf";
-			std::string out_file_format = "wb";
+			std::string out_file_format = "wb" + std::to_string(options["compression-level"].as < int > ());
 			out_fp_disc_sites = hts_open(out_filename_full.c_str(),out_file_format.c_str());
 			if (nthreads > 1) hts_set_threads(out_fp_disc_sites, nthreads);
 			out_hdr_disc_sites = bcf_hdr_dup(sr->readers[2].header);

--- a/docs/docs/documentation/concordance.md
+++ b/docs/docs/documentation/concordance.md
@@ -75,5 +75,6 @@ GLIMPSE2_concordance --gt-val --ac-bins 1 5 10 20 50 100 200 500 1000 2000 5000 
 | Option name 	       | Argument| Default  | Description |
 |:---------------------|:--------|:---------|:-------------------------------------|
 | \-O \[\-\-output \]  | STRING  | NA       | Prefix of the output files (extensions are automatically added) |
+| \-\-compression-level| INT     | 6        | Compression level for the BCF output produced by \-\-out-rej-sites/\-\-out-conc-sites/\-\-out-disc-sites: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 produces uncompressed BCF. |
 | \-\-log              | STRING  | NA       | Log file  |
 

--- a/docs/docs/documentation/ligate.md
+++ b/docs/docs/documentation/ligate.md
@@ -53,5 +53,7 @@ GLIMPSE2_ligate --input list_imputed_files_chr20.txt --output ligated_chr20.bcf 
 | Option name 	       | Argument| Default  | Description |
 |:---------------------|:--------|:---------|:-------------------------------------|
 | \-O \[\-\-output \]  | STRING  | NA       | Output ligated (phased) file in VCF/BCF format |
+| \-\-compression-level| INT     | 6        | Compression level for VCF/BCF output: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 with .bcf output produces an uncompressed BCF. Ignored for uncompressed VCF (.vcf). |
+| \-\-no-index         | STRING  | NA       | If specified, the ligated VCF/BCF is not indexed by GLIMPSE2 for random access to genomic regions |
 | \-\-log              | STRING  | NA       | Log file  |
 

--- a/docs/docs/documentation/phase.md
+++ b/docs/docs/documentation/phase.md
@@ -106,6 +106,7 @@ GLIMPSE2_phase --bam-list bams_1.0x.txt --reference binary_reference_panel_chr20
 | \-\-contigs-fai      | FILE    | NA       | If specified, header contig names and their lengths are copied from the  provided fasta index file (.fai). This allows to create imputed whole-genome files as contigs are present and can be easily merged by bcftools |
 | \-\-bgen-bits        | INT     | 8        | **Expert setting.** Only used together when the output is in BGEN file format. Specifies the number of bits to be used for the encoding probabilities of the output BGEN file. If the output is in the .vcf\[.gz\]/.bcf format, this value is ignored. Accepted values: 1-32. |
 | \-\-bgen-compr       | STRING  | zstd     | **Expert setting.** Only used together when the output is in BGEN file format. Specifies the compression of the output BGEN file. If the output is in the .vcf\[.gz\]/.bcf format, this value is ignored.  Accepted values: \[no,zlib,zstd\] |
+| \-\-compression-level| INT     | 6        | Compression level for VCF/BCF output: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 with .bcf output produces an uncompressed BCF. Ignored for uncompressed VCF (.vcf) and BGEN output. |
 | \-\-log              | FILE    | NA       | Log file  |
 | \-\-checkpoint-file-out | FILE | NA       | File to save checkpoint info in |
 

--- a/ligate/src/ligater/ligater_algorithm.cpp
+++ b/ligate/src/ligater/ligater_algorithm.cpp
@@ -226,6 +226,9 @@ void ligater::ligate() {
 	unsigned int file_type = OFILE_VCFU;
 	if (fname.size() > 6 && fname.substr(fname.size()-6) == "vcf.gz") { file_format = "wz"; file_type = OFILE_VCFC; }
 	if (fname.size() > 3 && fname.substr(fname.size()-3) == "bcf") { file_format = "wb"; file_type = OFILE_BCFC; }
+	//Append the compression level to the htslib mode string for compressed formats (wb/wz).
+	//Level 0 yields an uncompressed BCF; it has no effect on plain text VCF ("w").
+	if (file_format != "w") file_format += std::to_string(options["compression-level"].as < int > ());
 	bcf_srs_t * sr =  bcf_sr_init();
 	sr->require_index = 1;
 	int n_threads = options["threads"].as < int > ();

--- a/ligate/src/ligater/ligater_parameters.cpp
+++ b/ligate/src/ligater/ligater_parameters.cpp
@@ -40,6 +40,7 @@ void ligater::declare_options() {
 	bpo::options_description opt_output ("Output files");
 	opt_output.add_options()
 			("output,O", bpo::value< std::string >(), "Output ligated (phased) file in VCF/BCF format")
+			("compression-level", bpo::value< int >()->default_value(6), "Compression level for VCF/BCF output: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 with .bcf output produces an uncompressed BCF. Ignored for uncompressed VCF (.vcf).")
 			("log", bpo::value< std::string >(), "Log file");
 
 	descriptions.add(opt_base).add(opt_input).add(opt_output);
@@ -77,6 +78,9 @@ void ligater::check_options() {
 
 	if (options["threads"].as < int > () < 1)
 		vrb.error("Number of threads is a strictly positive number.");
+
+	if (options["compression-level"].as < int > () < 0 || options["compression-level"].as < int > () > 9)
+		vrb.error("Compression level must be between 0 and 9.");
 }
 
 void ligater::verbose_files() {
@@ -85,6 +89,10 @@ void ligater::verbose_files() {
 	vrb.title("Files:");
 	vrb.bullet("Input LIST     : [" + options["input"].as < std::string > () + "]");
 	vrb.bullet("Output VCF     : [" + options["output"].as < std::string > () + "]");
+	const std::string out_fname = options["output"].as < std::string > ();
+	const bool compressed_out =	(out_fname.size() > 6 && out_fname.substr(out_fname.size()-6) == "vcf.gz") ||
+								(out_fname.size() > 3 && out_fname.substr(out_fname.size()-3) == "bcf");
+	if (compressed_out) vrb.bullet("Compression    : [level " + stb.str(options["compression-level"].as < int > ()) + "]");
 	if (options.count("log")) vrb.bullet("Output LOG    : [" + options["log"].as < std::string > () + "]");
 }
 

--- a/phase/src/caller/caller_finalise.cpp
+++ b/phase/src/caller/caller_finalise.cpp
@@ -36,7 +36,7 @@ void caller::write_files_and_finalise() {
 	std::string out_file = options["output"].as < std::string > ();
 	//step1: writing best guess haplotypes in VCF/BCF file
 	if (output_fmt != OutputFormat::BGEN)
-		genotype_writer(H, G, V, *this).writeGenotypes(options["output"].as < std::string > (), output_fmt, output_compr, 0, options["main"].as < int > (), options["threads"].as < int > (), options.count("contigs-fai")?options["contigs-fai"].as <std::string> () : "");
+		genotype_writer(H, G, V, *this).writeGenotypes(options["output"].as < std::string > (), output_fmt, output_compr, options["compression-level"].as < int > (), 0, options["main"].as < int > (), options["threads"].as < int > (), options.count("contigs-fai")?options["contigs-fai"].as <std::string> () : "");
 	else
 	{
 		#ifdef __BGEN__
@@ -44,7 +44,7 @@ void caller::write_files_and_finalise() {
 		#else
 			//should have already thrown an error at the beginning. But ok let's not waste computation in the we arrive here
 			vrb.warning("Output in bgen format but the program seems to not support BGEN output. Switching to BCF (extension .bcf will added to output file)");
-			genotype_writer(H, G, V, *this).writeGenotypes(options["output"].as < std::string > () + ".bcf", OutputFormat::BCF, OutputCompression::ZLIB, 0, options["main"].as < int > (), options["threads"].as < int > (),options.count("contigs-fai")?options["contigs-fai"].as <std::string> () : "");
+			genotype_writer(H, G, V, *this).writeGenotypes(options["output"].as < std::string > () + ".bcf", OutputFormat::BCF, OutputCompression::ZLIB, options["compression-level"].as < int > (), 0, options["main"].as < int > (), options["threads"].as < int > (),options.count("contigs-fai")?options["contigs-fai"].as <std::string> () : "");
 			out_file += ".bcf";
 		#endif
 	}

--- a/phase/src/caller/caller_parameters.cpp
+++ b/phase/src/caller/caller_parameters.cpp
@@ -94,6 +94,7 @@ void caller::declare_options() {
 			("contigs-fai", bpo::value< std::string >(), "If specified, header contig names and their lengths are copied from the provided fasta index file (.fai). This allows to create imputed whole-genome files as contigs are present and can be easily merged by bcftools")
 			("bgen-bits", boost::program_options::value< int >()->default_value(8), "(Expert setting) Only used toghether when the output is in BGEN file format. Specifies the number of bits to be used for the encoding probabilities of the output BGEN file. If the output is in the .vcf[.gz]/.bcf format, this value is ignored. Accepted values: 1-32")
 			("bgen-compr", boost::program_options::value< std::string >()->default_value("zstd"), "(Expert setting) Only used toghether when the output is in BGEN file format. Specifies the compression of the output BGEN file. If the output is in the .vcf[.gz]/.bcf format, this value is ignored. Accepted values: [no,zlib,zstd]")
+			("compression-level", boost::program_options::value< int >()->default_value(6), "Compression level for VCF/BCF output: 0 uncompressed, 1 best speed, 9 best compression. A level of 0 with .bcf output produces an uncompressed BCF. Ignored for uncompressed VCF (.vcf) and BGEN output.")
 			("log", bpo::value< std::string >(), "Log file")
 			("checkpoint-file-out", bpo::value < std::string >(), "File to save checkpoint info in.");
 
@@ -141,6 +142,9 @@ void caller::check_options() {
 
 	if (options["threads"].as < int > () < 1)
 		vrb.error("Number of threads is a strictly positive number.");
+
+	if (options["compression-level"].as < int > () < 0 || options["compression-level"].as < int > () > 9)
+		vrb.error("Compression level must be between 0 and 9.");
 
 	std::string reference_filename = options["reference"].as<std::string>();
 	std::string ext0 = stb.get_extension(reference_filename);
@@ -275,6 +279,8 @@ void caller::verbose_files() {
 	std::array<std::string, 3> compr2string = { {"NO","ZLIB","ZSTD"} };
 	std::string n_bits = "";
 	if (output_fmt == OutputFormat::BGEN) n_bits = " - " + stb.str(bgen_bits) + " bits";
+	std::string compr_level = "";
+	if (output_fmt != OutputFormat::BGEN && output_compr != OutputCompression::NONE) compr_level = " level " + stb.str(options["compression-level"].as < int > ());
 
 	if (options.count("bam-list"))
 		vrb.bullet("List BAM/CRAM        : [" + options["bam-list"].as < std::string > () + "]");
@@ -293,7 +299,7 @@ void caller::verbose_files() {
 		vrb.bullet("Genetic Map          : [" + options["map"].as < std::string > () + "]");
 
 	vrb.bullet("Output file          : [" + options["output"].as < std::string > () + "]");
-	vrb.bullet("Output format        : [" + fmt2string[static_cast<int>(output_fmt)] + " format" + n_bits + " | " + compr2string[static_cast<int>(output_compr)] + " compression]");
+	vrb.bullet("Output format        : [" + fmt2string[static_cast<int>(output_fmt)] + " format" + n_bits + " | " + compr2string[static_cast<int>(output_compr)] + " compression" + compr_level + "]");
 
 
 	if (options.count("log")) vrb.bullet("Output LOG           : [" + options["log"].as < std::string > () + "]");

--- a/phase/src/io/genotype_writer.cpp
+++ b/phase/src/io/genotype_writer.cpp
@@ -40,7 +40,7 @@ genotype_writer::genotype_writer(const haplotype_set & _H, const genotype_set & 
 genotype_writer::~genotype_writer() {
 }
 
-void genotype_writer::writeGenotypes(const std::string fname, OutputFormat output_fmt, OutputCompression output_compr, const int n_bits_bgen, const int n_main, const int n_threads, const std::string fai_fname) const {
+void genotype_writer::writeGenotypes(const std::string fname, OutputFormat output_fmt, OutputCompression output_compr, const int compression_level, const int n_bits_bgen, const int n_main, const int n_threads, const std::string fai_fname) const {
 	tac.clock();
 	unsigned int file_type = OFILE_BCFC;
 	std::string file_format = "wb";
@@ -50,6 +50,10 @@ void genotype_writer::writeGenotypes(const std::string fname, OutputFormat outpu
 		if (output_compr == OutputCompression::NONE) {file_format = "w"; file_type = OFILE_VCFU;}
 		else {file_format = "wz"; file_type = OFILE_VCFC;}
 	}
+
+	//Append the compression level to the htslib mode string for compressed formats (wb/wz).
+	//Level 0 yields an uncompressed BCF; it has no effect on plain text VCF ("w").
+	if (file_format != "w") file_format += std::to_string(compression_level);
 
 	htsFile * fp = hts_open(fname.c_str(),file_format.c_str());
 	if (n_threads > 1) hts_set_threads(fp, n_threads);

--- a/phase/src/io/genotype_writer.h
+++ b/phase/src/io/genotype_writer.h
@@ -49,7 +49,7 @@ public:
 	genotype_writer(const haplotype_set &, const genotype_set &, const variant_map &, const caller & C);
 	~genotype_writer();
 
-	void writeGenotypes(const std::string fname, OutputFormat oformat, OutputCompression ocompr, const int n_bits_bgen, const int n_main, const int n_threads, const std::string fai_fname) const;
+	void writeGenotypes(const std::string fname, OutputFormat oformat, OutputCompression ocompr, const int compression_level, const int n_bits_bgen, const int n_main, const int n_threads, const std::string fai_fname) const;
 	void update_header_from_fai(bcf_hdr_t * hdr, const std::string fai_fname) const;
 
 #ifdef __BGEN__


### PR DESCRIPTION
### Motivation

`GLIMPSE2_phase`, `GLIMPSE2_ligate`, and `GLIMPSE2_concordance` hardcode the htslib
output mode to compressed BCF (`"wb"`) / compressed VCF (`"wz"`), so there is no way
to change the compression level or to emit an uncompressed BCF. Every run pays full
(level-6) compression cost, which is wasteful for large intermediate files that the
next pipeline stage immediately re-reads and decompresses.

@srubinacci this is a purely mechanical change in the output compression/writing layer, so hopefully can be reviewed (and merged) even without the ability to benchmark on UKB?

### Change

Adds a `--compression-level` option (INT, default 6, range 0–9) to all three tools,
mirroring `bcftools -l/--compression-level` so the semantics are familiar:

- The level is appended to the htslib mode string only for compressed formats
  (`wb`/`wz`); plain uncompressed VCF (`.vcf`) is left untouched.
- **Level 0 yields a BGZF-stored (uncompressed) BCF** — still BGZF-framed and
  indexable, just not deflated — equivalent to `bcftools -l 0`.
- The default of 6 matches htslib's implicit default, so output is **byte-identical**
  when the flag is unused.

| Tool | Output affected |
|------|-----------------|
| phase | main VCF/BCF output (BGEN path unaffected — it has its own `--bgen-compr`) |
| ligate | ligated VCF/BCF output |
| concordance | `_rej_sites.bcf` / `_conc_sites.bcf` / `_disc_sites.bcf` diagnostic outputs |

Help text, startup logging, and the per-tool documentation tables are updated for all
three tools.

### Testing

- All three tools build cleanly.
- Out-of-range values (e.g. `--compression-level 12`) are rejected with a clear error.
- Level 0 produces an uncompressed BCF matching `bcftools -Ob0`; higher levels compress;
  decoded records are identical across levels.
- Verified byte-identical default output against current `master` (matching MD5).
- ligate's inline CSI index at level 0 verified usable (region query + `bcftools index -s`).
