### PR TITLE
Retry transient read errors during input (VCF, binary) streaming in Glimpse phase

### DIFF
--- a/concordance/src/containers/call_set_reading.cpp
+++ b/concordance/src/containers/call_set_reading.cpp
@@ -85,7 +85,7 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 		{
 			if(!(bcf_sr_add_reader (sr, fnames[reader_id].c_str())))
 			{
-				if (sr->errnum != idx_load_failed) vrb.error("Failed to open file: " + fnames[reader_id] + "");
+				if (sr->errnum != idx_load_failed) vrb.error("Failed to open file [" + fnames[reader_id] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
 				bcf_sr_remove_reader (sr, reader_id);
 				int ret = bcf_index_build3(fnames[reader_id].c_str(), NULL, 14, options["threads"].as < int > ());
 
@@ -98,7 +98,7 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 					else
 						vrb.error("index: failed to create index for + " + fnames[reader_id]);
 				}
-				if(!(bcf_sr_add_reader (sr, fnames[reader_id].c_str()))) vrb.error("Problem opening/creating index file for [" + fnames[reader_id] + "]");
+				if(!(bcf_sr_add_reader (sr, fnames[reader_id].c_str()))) vrb.error("Problem opening/creating index file for [" + fnames[reader_id] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
 				else vrb.bullet("Index file for [" + fnames[reader_id] + "] has been successfully created.\n");
 			}
 		}
@@ -822,6 +822,10 @@ void call_set::readData(std::vector < std::string > & ftruth, std::vector < std:
 					++n_disc_var_af;
 			}
 		}
+		//A nonzero errnum means the read loop stopped on a read failure, not a clean EOF.
+		//Without this check a truncated/dropped (e.g. cloud-streamed) input would look like
+		//the file simply ended, silently skewing the concordance statistics.
+		if (sr->errnum) vrb.error("Error reading VCF/BCF mid-stream while reading inputs for region [" + region[f] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". One of the truth/estimated/frequency files may be incomplete or, if cloud-streamed, the read dropped.");
 		if (itmp) free(itmp);
 		free(af_ptr);
 		free(pl_arr_t);

--- a/ligate/src/ligater/ligater_algorithm.cpp
+++ b/ligate/src/ligater/ligater_algorithm.cpp
@@ -26,6 +26,8 @@
 #include <ligater/ligater_header.h>
 #include <htslib/khash.h>
 #include <sys/stat.h>
+#include <cstring>
+#include <cerrno>
 #include <utils/otools.h>
 #include <utils/basic_stats.h>
 
@@ -143,8 +145,8 @@ void ligater::scan_overlap(const int ifname, const char * seek_chr, int seek_pos
 	int n_threads = options["threads"].as < int > ();
 	if (n_threads > 1) bcf_sr_set_threads(sr, n_threads);
 
-	if (!bcf_sr_add_reader (sr, filenames[ifname-2].c_str())) vrb.error("Problem opening/creating index file for [" + filenames[ifname-2] + "]");
-	if (!bcf_sr_add_reader (sr, filenames[ifname-1].c_str())) vrb.error("Problem opening/creating index file for [" + filenames[ifname-1] + "]");
+	if (!bcf_sr_add_reader (sr, filenames[ifname-2].c_str())) vrb.error("Failed to open/index [" + filenames[ifname-2] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
+	if (!bcf_sr_add_reader (sr, filenames[ifname-1].c_str())) vrb.error("Failed to open/index [" + filenames[ifname-1] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
 
 	int nset = 0;
 	int n_sites_buff = 0;
@@ -177,6 +179,10 @@ void ligater::scan_overlap(const int ifname, const char * seek_chr, int seek_pos
 		++n_sites_buff;
 		++n_sites_tot;
 	}
+	//A nonzero errnum here means the loop stopped on a read failure, not a clean EOF.
+	//Without this check a truncated/dropped (e.g. cloud-streamed) input would look like
+	//the file simply ended, silently corrupting the overlap scan.
+	if (sr->errnum) vrb.error("Error reading VCF/BCF mid-stream while scanning the overlap of [" + filenames[ifname-2] + "] / [" + filenames[ifname-1] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". An input chunk may be incomplete or, if cloud-streamed, the read dropped.");
 	bcf_sr_destroy(sr);
 
 	stats1D stats_all;
@@ -231,8 +237,8 @@ void ligater::ligate() {
 
 	for (int f = 0, prev_chrid = -1 ; f < nfiles ; f ++)
 	{
-		htsFile *fp = hts_open(filenames[f].c_str(), "r"); if ( !fp ) vrb.error("Failed to open: " + filenames[f] + ".");
-		bcf_hdr_t *hdr = bcf_hdr_read(fp); if ( !hdr ) vrb.error("Failed to parse header: " + filenames[f] +".");
+		htsFile *fp = hts_open(filenames[f].c_str(), "r"); if ( !fp ) vrb.error("Failed to open [" + filenames[f] + "] (" + std::string(strerror(errno)) + "). The file may be missing, unreadable, or (if cloud-streamed) the read may have failed.");
+		bcf_hdr_t *hdr = bcf_hdr_read(fp); if ( !hdr ) vrb.error("Failed to parse header of [" + filenames[f] +"]. The file may be malformed or truncated (e.g. an incomplete cloud-stream).");
 		out_hdr = bcf_hdr_merge(out_hdr,hdr);
         if ( bcf_hdr_nsamples(hdr) != bcf_hdr_nsamples(out_hdr) ) vrb.error("Different number of samples in " + filenames[f] + ".");
         for (int j=0; j<bcf_hdr_nsamples(hdr); j++)
@@ -337,7 +343,7 @@ void ligater::ligate() {
         int new_file = 0;
         while ( sr->nreaders < 2 && ifname < nfiles )
         {
-            if ( !bcf_sr_add_reader (sr, filenames[ifname].c_str())) vrb.error("Failed to open " + filenames[ifname] + ".");
+            if ( !bcf_sr_add_reader (sr, filenames[ifname].c_str())) vrb.error("Failed to open/index [" + filenames[ifname] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
             new_file = 1;
             ifname++;
             if ( start_pos[ifname-1]==-1 ) break;   // new chromosome, start with only one file open
@@ -374,7 +380,7 @@ void ligater::ligate() {
             while ( ifname < nfiles && start_pos[ifname]!=-1 && line->pos >= start_pos[ifname] )
             {
                 must_seek = 1;
-                if ( !bcf_sr_add_reader(sr, filenames[ifname].c_str())) vrb.error("Failed to open " + filenames[ifname] + ".");
+                if ( !bcf_sr_add_reader(sr, filenames[ifname].c_str())) vrb.error("Failed to open/index [" + filenames[ifname] + "]: " + std::string(bcf_sr_strerror(sr->errnum)) + ". The file may be missing, malformed, or (if cloud-streamed) the read may have failed.");
                 if  (sr->nreaders>2) vrb.error("Three files overlapping at position: " + std::to_string(line->pos+1));
                 ifname++;
             }
@@ -439,6 +445,10 @@ void ligater::ligate() {
             prev_readers_size = sr->nreaders;
     		n_variants++;
         }
+        //A nonzero errnum means the inner read loop stopped on a read failure rather than
+        //a clean end-of-input; without this check a truncated/dropped (e.g. cloud-streamed)
+        //chunk would be silently concatenated as if complete.
+        if (sr->errnum) vrb.error("Error reading VCF/BCF mid-stream during concatenation: " + std::string(bcf_sr_strerror(sr->errnum)) + ". An input chunk may be incomplete or, if cloud-streamed, the read dropped.");
         if ( sr->nreaders ) while ( sr->nreaders ) bcf_sr_remove_reader(sr, 0);
     }
 	vrb.print("Cnk " + stb.str(ifname-1) + " [" + prev_chr + ":" + stb.str(first_pos) + "-" + stb.str(prev_pos[0] + 1) + "] [L=" + stb.str(n_variants-n_variants_at_start_cnk) + "]" );

--- a/phase/src/caller/caller_header.h
+++ b/phase/src/caller/caller_header.h
@@ -99,6 +99,14 @@ public:
 	//FILE I/O
 	void print_ref_panel_info(const std::string ref_string);
 	void read_files_and_initialise();
+	//Single attempt at reading the binary reference panel (haplotype_set H +
+	//variant_map V). Returns true on success; on failure fills err_msg and returns
+	//false so the caller can retry transient localization/read failures (panel
+	//streamed or localized from a cloud filesystem). Each call re-opens the file and
+	//boost overwrites H/V, so a retry restarts the read from a clean archive. When the
+	//failure is non-retryable (e.g. a GLIMPSE/boost version mismatch), non_retryable is
+	//set to true so the caller can stop immediately instead of burning its retries.
+	bool read_binary_reference_panel(const std::string& reference_filename, std::string& err_msg, bool& non_retryable);
 	void setup_mpileup();
 	void read_BAMs();
 	

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -32,7 +32,7 @@
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/archive_exception.hpp>
 #include <containers/glimpse_mpileup.h>
-#include <thread>
+#include <io/retry_io.h>
 #include <chrono>
 
 void caller::print_ref_panel_info(const std::string ref_string)
@@ -96,19 +96,12 @@ void caller::read_files_and_initialise() {
 			//attempt re-opens the file and boost overwrites H/V, so every retry restarts
 			//from a clean archive.
 			vrb.bullet("Localizing binary reference panel [" + reference_filename + "] via retry-enabled read");
-			const int n_retry = 3;
-			int n_retry_remain = n_retry;
-			std::chrono::seconds delay(1);
-			std::string err_msg;
-			bool non_retryable = false;
-			for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
-			{
-				if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
-				if (read_binary_reference_panel(reference_filename, err_msg, non_retryable)) break;
-				if (non_retryable) vrb.error("Non-retryable error while reading binary reference panel [" + reference_filename + "]: " + err_msg + ". This looks like a version mismatch, please ensure you are using the same GLIMPSE and boost library version.");
-				vrb.warning("Error while reading binary reference panel [" + reference_filename + "]: " + err_msg + ". " + std::to_string(n_retry_remain) + " retries remaining");
-			}
-			if (n_retry_remain == 0) vrb.error("Max number of retries attempted while reading binary reference panel [" + reference_filename + "]. Last error: " + err_msg + ". If this is a version mismatch, please ensure you are using the same GLIMPSE and boost library version.");
+			retry_with_backoff("reading binary reference panel [" + reference_filename + "]", 3, std::chrono::seconds(1), [&]() -> attempt_result {
+				std::string err_msg;
+				bool non_retryable = false;
+				const bool ok = read_binary_reference_panel(reference_filename, err_msg, non_retryable);
+				return { ok, non_retryable, err_msg };
+			});
 
 			vrb.bullet("Binary reference panel parsing [done] (" + stb.str(tac.rel_time()*1.0/1000, 2) + "s)");
 			print_ref_panel_info("Binary");
@@ -187,21 +180,25 @@ bool caller::read_binary_reference_panel(const std::string& reference_filename, 
 	err_msg.clear();
 	non_retryable = false;
 
-	//(1) Open the (possibly cloud-localized) file. A transient localization failure
-	//shows up here as a non-good() stream; report it so the caller can retry.
+	//(1) Open the file. A failure to open is not a transient localization hiccup: on the
+	//common case (a missing or mistyped --reference path) retrying just delays the
+	//failure, so report it precisely and mark it non_retryable to fail fast (matching the
+	//pre-retry behaviour). Transient localization failures surface later, as read errors
+	//during deserialization, not as a failed open.
 	std::ifstream ifs(reference_filename, std::ios::binary | std::ios_base::in);
 	if (!ifs.good())
 	{
-		err_msg = "could not open file (not good(): eofbit, failbit or badbit set, or file not found/not yet localized)";
+		err_msg = "could not open file (not good(): eofbit, failbit or badbit set, or file not found). Please check the path.";
+		non_retryable = true;
 		return false;
 	}
 
 	//(2) Deserialize the archive. boost overwrites H/V in place, so a failed attempt
 	//here leaves them partially written; the next retry re-opens and overwrites again,
 	//restarting from a clean archive. A truncated/incomplete localization surfaces as a
-	//retryable boost archive exception (e.g. input_stream_error), but a genuine
-	//GLIMPSE/boost version mismatch is non_retryable: retrying will never help, so flag
-	//it and let the caller stop immediately instead of burning its retries.
+	//retryable input_stream_error (EOF mid-stream); a bad/wrong archive header
+	//(invalid_signature) or a GLIMPSE/boost version mismatch are non_retryable, since the
+	//bytes already read are wrong and retrying will never help.
 	try
 	{
 		boost::archive::binary_iarchive ia(ifs);
@@ -210,6 +207,7 @@ bool caller::read_binary_reference_panel(const std::string& reference_filename, 
 	}
 	catch (const boost::archive::archive_exception& e)
 	{
+		std::string hint;
 		switch (e.code)
 		{
 		case boost::archive::archive_exception::unsupported_version:
@@ -217,14 +215,18 @@ bool caller::read_binary_reference_panel(const std::string& reference_filename, 
 		case boost::archive::archive_exception::unregistered_class:
 		case boost::archive::archive_exception::incompatible_native_format:
 			non_retryable = true;
+			hint = ". This looks like a version mismatch; please ensure you are using the same GLIMPSE and boost library versions";
+			break;
+		case boost::archive::archive_exception::invalid_signature:
+			non_retryable = true;
+			hint = ". The file is not a valid GLIMPSE binary reference panel";
 			break;
 		default:
-			//Everything else (input_stream_error from a truncated/partial read,
-			//invalid_signature from a not-yet-localized placeholder, etc.) is
+			//input_stream_error and the like (truncated/partial read mid-stream) are
 			//treated as transient and left retryable.
 			break;
 		}
-		err_msg = std::string("exception while parsing boost archive: ") + e.what();
+		err_msg = std::string("exception while parsing boost archive: ") + e.what() + hint;
 		return false;
 	}
 	catch (std::exception& e)

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -182,9 +182,8 @@ bool caller::read_binary_reference_panel(const std::string& reference_filename, 
 
 	//(1) Open the file. A failure to open is not a transient localization hiccup: on the
 	//common case (a missing or mistyped --reference path) retrying just delays the
-	//failure, so report it precisely and mark it non_retryable to fail fast (matching the
-	//pre-retry behaviour). Transient localization failures surface later, as read errors
-	//during deserialization, not as a failed open.
+	//failure, so report it precisely and mark it non_retryable to fail fast. Transient
+	// localization failures surface later, as read errors during deserialization.
 	std::ifstream ifs(reference_filename, std::ios::binary | std::ios_base::in);
 	if (!ifs.good())
 	{

--- a/phase/src/caller/caller_initialise.cpp
+++ b/phase/src/caller/caller_initialise.cpp
@@ -30,7 +30,10 @@
 #include <io/gmap_reader.h>
 #include <io/genotype_bam_caller.h>
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/archive_exception.hpp>
 #include <containers/glimpse_mpileup.h>
+#include <thread>
+#include <chrono>
 
 void caller::print_ref_panel_info(const std::string ref_string)
 {
@@ -87,20 +90,25 @@ void caller::read_files_and_initialise() {
 		vrb.wait("  * Binary reference panel parsing");
 		tac.clock();
 		{
-			std::ifstream ifs(reference_filename, std::ios::binary | std::ios_base::in);
-			if (!ifs.good()) vrb.error("Reading binary reference panel file: [" + reference_filename + "]. File not good(): eofbit, failbit or badbit set or file not found.");
-			try
+			//Localizing/reading the binary reference panel can transiently fail when the
+			//panel is streamed or localized from a cloud filesystem. Retry the whole read
+			//(open + deserialize + sanity check) a few times with exponential backoff. Each
+			//attempt re-opens the file and boost overwrites H/V, so every retry restarts
+			//from a clean archive.
+			vrb.bullet("Localizing binary reference panel [" + reference_filename + "] via retry-enabled read");
+			const int n_retry = 3;
+			int n_retry_remain = n_retry;
+			std::chrono::seconds delay(1);
+			std::string err_msg;
+			bool non_retryable = false;
+			for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
 			{
-				boost::archive::binary_iarchive ia(ifs);
-				ia >> H;
-				ia >> V;
-			} catch (std::exception& e ) {
-				std::stringstream err_str;
-				err_str <<"problems reading the binary reference panel (exception triggered by boost archive). Please ensure you are using the same GLIMPSE and boost library version";
-				err_str << e.what();
-				vrb.error(err_str.str());
+				if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
+				if (read_binary_reference_panel(reference_filename, err_msg, non_retryable)) break;
+				if (non_retryable) vrb.error("Non-retryable error while reading binary reference panel [" + reference_filename + "]: " + err_msg + ". This looks like a version mismatch, please ensure you are using the same GLIMPSE and boost library version.");
+				vrb.warning("Error while reading binary reference panel [" + reference_filename + "]: " + err_msg + ". " + std::to_string(n_retry_remain) + " retries remaining");
 			}
-			if (H.Ypacked.size()==0) vrb.error("Problem reading binary file format. Empty PBWT detected.");
+			if (n_retry_remain == 0) vrb.error("Max number of retries attempted while reading binary reference panel [" + reference_filename + "]. Last error: " + err_msg + ". If this is a version mismatch, please ensure you are using the same GLIMPSE and boost library version.");
 
 			vrb.bullet("Binary reference panel parsing [done] (" + stb.str(tac.rel_time()*1.0/1000, 2) + "s)");
 			print_ref_panel_info("Binary");
@@ -172,6 +180,68 @@ void caller::read_files_and_initialise() {
 		V.update_checksum(crc);
 	}
 
+}
+
+bool caller::read_binary_reference_panel(const std::string& reference_filename, std::string& err_msg, bool& non_retryable)
+{
+	err_msg.clear();
+	non_retryable = false;
+
+	//(1) Open the (possibly cloud-localized) file. A transient localization failure
+	//shows up here as a non-good() stream; report it so the caller can retry.
+	std::ifstream ifs(reference_filename, std::ios::binary | std::ios_base::in);
+	if (!ifs.good())
+	{
+		err_msg = "could not open file (not good(): eofbit, failbit or badbit set, or file not found/not yet localized)";
+		return false;
+	}
+
+	//(2) Deserialize the archive. boost overwrites H/V in place, so a failed attempt
+	//here leaves them partially written; the next retry re-opens and overwrites again,
+	//restarting from a clean archive. A truncated/incomplete localization surfaces as a
+	//retryable boost archive exception (e.g. input_stream_error), but a genuine
+	//GLIMPSE/boost version mismatch is non_retryable: retrying will never help, so flag
+	//it and let the caller stop immediately instead of burning its retries.
+	try
+	{
+		boost::archive::binary_iarchive ia(ifs);
+		ia >> H;
+		ia >> V;
+	}
+	catch (const boost::archive::archive_exception& e)
+	{
+		switch (e.code)
+		{
+		case boost::archive::archive_exception::unsupported_version:
+		case boost::archive::archive_exception::unsupported_class_version:
+		case boost::archive::archive_exception::unregistered_class:
+		case boost::archive::archive_exception::incompatible_native_format:
+			non_retryable = true;
+			break;
+		default:
+			//Everything else (input_stream_error from a truncated/partial read,
+			//invalid_signature from a not-yet-localized placeholder, etc.) is
+			//treated as transient and left retryable.
+			break;
+		}
+		err_msg = std::string("exception while parsing boost archive: ") + e.what();
+		return false;
+	}
+	catch (std::exception& e)
+	{
+		err_msg = std::string("exception while parsing boost archive: ") + e.what();
+		return false;
+	}
+
+	//(3) Sanity check the deserialized panel. An empty PBWT indicates a corrupt or
+	//incompletely localized file; treat as a retryable failure.
+	if (H.Ypacked.size() == 0)
+	{
+		err_msg = "empty PBWT detected after parsing (corrupt or incompletely localized binary file)";
+		return false;
+	}
+
+	return true;
 }
 
 

--- a/phase/src/io/genotype_reader.cpp
+++ b/phase/src/io/genotype_reader.cpp
@@ -27,11 +27,31 @@
 #include <io/retry_io.h>
 #include <thread>
 #include <chrono>
+#include <cstring>
+#include <cerrno>
 
 std::map<std::string, int> mapPloidy = {
 		{"1",1},
 		{"2",2}
 };
+
+//Synced-reader pass result sentinels (distinct from htslib's bcf_sr_error codes, which are
+//0..10). open_failed is 0 in htslib's enum and errnum is zero-initialized, so a raw errnum
+//of 0 is ambiguous; these sentinels give the streaming passes an unambiguous nonzero code.
+static constexpr int SR_OPEN_FAILED = -1;	//bcf_sr_add_reader failed to open/index
+static constexpr int SR_TRUNCATED   = -2;	//scan/parse site counts disagree -> a pass was truncated
+
+//Build a human-readable description of a synced-reader failure. bcf_sr_strerror returns an
+//empty string for several codes (including the open_failed==0 case and anything we cannot
+//map), so fall back to errno and, failing that, point at htslib's own [E::...] stderr lines
+//which carry the real underlying cause (e.g. libcurl/bgzf errors when cloud-streaming).
+static std::string describe_sr_error(int errnum, int saved_errno)
+{
+	const char * s = bcf_sr_strerror(errnum);
+	if (s && s[0]) return std::string(s);
+	if (saved_errno) return std::string(strerror(saved_errno));
+	return "no detail available from htslib (error code " + std::to_string(errnum) + "); see the [E::...] messages above for the underlying cause";
+}
 
 genotype_reader::genotype_reader(
 		haplotype_set & _H,
@@ -139,7 +159,7 @@ void genotype_reader::initReader(bcf_srs_t *sr, std::string& file, int nthreads)
 	}
 }
 
-int genotype_reader::openTargetReader(bcf_srs_t *sr, std::string& file, int nthreads)
+int genotype_reader::openTargetReader(bcf_srs_t *sr, std::string& file, int nthreads, std::string& err_out)
 {
 	sr->require_index = 1;
 	//Region/target setup failures are deterministic config errors, not transient cloud
@@ -149,9 +169,16 @@ int genotype_reader::openTargetReader(bcf_srs_t *sr, std::string& file, int nthr
 
 	if (nthreads>1) bcf_sr_set_threads(sr, nthreads);
 
-	//A failed open/index load is the most common transient cloud-streaming failure;
-	//return the errnum (nonzero) so the caller can retry instead of aborting here.
-	if(!(bcf_sr_add_reader (sr, file.c_str()))) return sr->errnum ? sr->errnum : -1;
+	//A failed open/index load is the most common transient cloud-streaming failure; return
+	//a nonzero code so the caller can retry instead of aborting here. Capture errno right
+	//here (it carries the real cause, e.g. EPERM on a flaky GCS read) before bcf_sr_destroy
+	//or anything else can clobber it; bcf_sr_strerror often returns nothing for open_failed.
+	errno = 0;
+	if(!(bcf_sr_add_reader (sr, file.c_str())))
+	{
+		err_out = "failed to open/index file: " + describe_sr_error(sr->errnum, errno);
+		return SR_OPEN_FAILED;
+	}
 	return 0;
 }
 
@@ -293,42 +320,41 @@ void genotype_reader::scanGenotypes(bcf_srs_t * sr) {
 void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 {
 	//Retries are not implemented in hfile_libcurl (used when streaming from a cloud
-	//location), so we retry transient read failures of each streaming pass here. The
-	//scan only accumulates into the local vec_pos_tar (reset by clearing it at the start
-	//of scanTarGenotypes) and reads the sample names/header, and the parse overwrites the
-	//genotype set by site index, so each retry restarts the pass from a clean state.
+	//location), so we retry transient read failures here. The target file is read in two
+	//streaming passes - scan (sample names + the per-site list) then parse (fill the
+	//genotype set by site index) - and BOTH are wrapped in a single retry: htslib does not
+	//reliably set errnum on a mid-stream read failure (open_failed==0, errnum zero-init), so
+	//a transient glitch can silently truncate the scan and only show up as a scan/parse
+	//site-count mismatch in the parse pass. Retrying the pair re-runs the scan from a clean
+	//vec_pos_tar, so a one-off glitch is recovered instead of aborting the run.
 	vrb.bullet("Reading target GLs from [" + fmain + "] via retry-enabled streaming path (binary reference panel)");
-	const int n_retry = 3;
-	const std::chrono::seconds base_delay(1);
-
 	std::vector<variant*> vec_pos_tar;
+	bool ploidy_set = false;
 
-	vrb.wait("  * VCF/BCF scanning");
+	vrb.wait("  * VCF/BCF scanning + parsing");
 	tac.clock();
-	retry_with_backoff("scanning target GLs [" + fmain + "]", n_retry, base_delay, [&]() -> attempt_result {
-		const int err = scanTarGenotypes(fmain, nthreads, vec_pos_tar);
-		return { err == 0, false, err ? std::string(bcf_sr_strerror(err)) : std::string() };
-	});
+	retry_with_backoff("reading target GLs [" + fmain + "]", 3, std::chrono::seconds(1), [&]() -> attempt_result {
+		std::string err;
+		const int scan_err = scanTarGenotypes(fmain, nthreads, vec_pos_tar, err);
+		if (scan_err) return { false, false, err };
 
-	//Sample names + ploidy are now known from the (retried) scan pass; set_ploidy_tar
-	//allocates the genotype set, so it must run exactly once, after a successful scan and
-	//before the parse pass writes into it.
-	set_ploidy_tar();
+		//set_ploidy_tar allocates the genotype set from the panel-derived site count and the
+		//sample header - it does not depend on the scanned target sites - so it is run once
+		//after the first successful scan and reused across parse retries.
+		if (!ploidy_set) { set_ploidy_tar(); ploidy_set = true; }
 
-	vrb.wait("  * VCF/BCF parsing");
-	tac.clock();
-	retry_with_backoff("parsing target GLs [" + fmain + "]", n_retry, base_delay, [&]() -> attempt_result {
-		const int err = parseTarGenotypes(fmain, nthreads, vec_pos_tar);
-		return { err == 0, false, err ? std::string(bcf_sr_strerror(err)) : std::string() };
+		const int parse_err = parseTarGenotypes(fmain, nthreads, vec_pos_tar, err);
+		if (parse_err) return { false, false, err };
+		return { true, false, std::string() };
 	});
 }
 
-int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar)
+int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar, std::string& err_out)
 {
 	vec_pos_tar.clear(); //reset any partial accumulation from a failed attempt
 
 	bcf_srs_t * sr_scan = bcf_sr_init();
-	const int open_err = openTargetReader(sr_scan, fmain, nthreads);
+	const int open_err = openTargetReader(sr_scan, fmain, nthreads, err_out);
 	if (open_err) { bcf_sr_destroy(sr_scan); return open_err; }
 	sr_scan->max_unpack = BCF_UN_INFO;
 
@@ -349,12 +375,17 @@ int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vect
 		if (vecS.size() > 0) vec_pos_tar.push_back(vecS[0]);
 		else vec_pos_tar.push_back(nullptr);
 	}
+	//NB: htslib may end the loop on a mid-stream read failure WITHOUT setting errnum, in
+	//which case this returns 0 and the truncated vec_pos_tar is caught downstream by the
+	//parse pass's site-count cross-check (SR_TRUNCATED).
+	const int saved_errno = errno;
 	const int err = sr_scan->errnum;
 	bcf_sr_destroy(sr_scan);
+	if (err) err_out = describe_sr_error(err, saved_errno);
 	return err;
 }
 
-int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar)
+int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar, std::string& err_out)
 {
 	bcf1_t * line_main = NULL;
 	int npl_main, npl_arr_main = 0, *pl_arr_main = NULL;
@@ -366,20 +397,22 @@ int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const st
 	float *ptr_f;
 	int i_site=0;
 	const int n_ref_haps = H.n_ref_haps;
+	bool truncated = false;
 
 	bcf_srs_t * sr_parse =  bcf_sr_init();
-	const int open_err = openTargetReader(sr_parse, fmain, nthreads);
+	const int open_err = openTargetReader(sr_parse, fmain, nthreads, err_out);
 	if (open_err) { bcf_sr_destroy(sr_parse); return open_err; }
 	sr_parse->max_unpack = BCF_UN_ALL;
 
 	while (bcf_sr_next_line (sr_parse))
 	{
 		if (!bcf_sr_has_line(sr_parse, 0) || bcf_sr_get_line(sr_parse, 0)->n_allele != 2) continue; //always ref
-		//The scan and parse passes are independent re-opens; if the parse pass yields more
-		//surviving sites than the scan recorded (e.g. the file changed between passes),
-		//indexing vec_pos_tar[i_site] would read past its end. Fail loudly instead.
-		if (i_site >= (int)vec_pos_tar.size())
-			vrb.error("Target GL file [" + fmain + "] returned more sites while parsing than while scanning (" + std::to_string(vec_pos_tar.size()) + "). The file may have changed between the two streaming passes.");
+		//The scan and parse passes are independent re-opens applying the same filter, so they
+		//must yield the same number of biallelic sites. If the parse pass yields MORE, one
+		//pass was truncated by a transient read error (htslib may not flag this via errnum) -
+		//stop before indexing vec_pos_tar[i_site] out of bounds and report a retryable
+		//truncation rather than corrupting output.
+		if (i_site >= (int)vec_pos_tar.size()) { truncated = true; break; }
 		if (vec_pos_tar[i_site] == nullptr)
 		{
 			++i_site;
@@ -467,10 +500,23 @@ int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const st
 			++i_site;
 		}
 	}
+	//If the parse pass read FEWER biallelic sites than the scan recorded (and did not
+	//already overrun above), it was itself truncated mid-stream. Either direction means a
+	//pass did not complete, so report a retryable truncation.
+	if (!truncated && i_site != (int)vec_pos_tar.size()) truncated = true;
+
+	const int saved_errno = errno;
 	const int err = sr_parse->errnum;
 	bcf_sr_destroy(sr_parse);
 	free(pl_arr_main);
 	free(gl_arr_main);
+
+	if (truncated)
+	{
+		err_out = "scan/parse site-count mismatch (scanned " + std::to_string(vec_pos_tar.size()) + ", parsed " + std::to_string(i_site) + "+); a streaming pass was likely truncated by a transient read error";
+		return SR_TRUNCATED;
+	}
+	if (err) err_out = describe_sr_error(err, saved_errno);
 	return err;
 }
 

--- a/phase/src/io/genotype_reader.cpp
+++ b/phase/src/io/genotype_reader.cpp
@@ -179,6 +179,7 @@ void genotype_reader::initReader(bcf_srs_t *sr, std::string& fmain, std::string&
 
 void genotype_reader::readGenotypes(std::string fmain, std::string fref, int nthreads)
 {
+	vrb.bullet("Reading target GLs from [" + fmain + "] via synced-reader path (VCF/BCF reference panel) -- NO streaming retries on this path");
 	bcf_srs_t * sr_scan =  bcf_sr_init();
 
 	initReader(sr_scan, fmain, fref, nthreads);
@@ -295,6 +296,7 @@ void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 	//scan only accumulates into the local vec_pos_tar (reset by clearing it at the
 	//start of scanTarGenotypes), and the parse overwrites the genotype set by site
 	//index, so each retry restarts the pass from a clean state.
+	vrb.bullet("Reading target GLs from [" + fmain + "] via retry-enabled streaming path (binary reference panel)");
 	vrb.wait("  * VCF/BCF scanning");
 	tac.clock();
 	{

--- a/phase/src/io/genotype_reader.cpp
+++ b/phase/src/io/genotype_reader.cpp
@@ -24,6 +24,8 @@
  ******************************************************************************/
 
 #include <io/genotype_reader.h>
+#include <thread>
+#include <chrono>
 
 std::map<std::string, int> mapPloidy = {
 		{"1",1},
@@ -245,6 +247,7 @@ void genotype_reader::scanGenotypesCommon(bcf_srs_t * sr, int ref_sr_n /* Refere
 		V.push(new variant (line_ref->pos + 1, std::string(line_ref->d.id), line_ref->d.allele[0], line_ref->d.allele[1], line_type, V.size(), cref, calt, line_type==VCF_SNP && (line_ref->pos != prev_pos)));
 		prev_pos=line_ref->pos;
 	}
+	if (sr->errnum) vrb.error("Error while scanning VCF/BCF file(s): " + std::string(bcf_sr_strerror(sr->errnum)));
 	free(vAC);
 	free(vAN);
 	if (H.n_tot_sites == 0) vrb.error("No variants to be imputed in files");
@@ -271,33 +274,77 @@ void genotype_reader::scanGenotypes(bcf_srs_t * sr) {
 }
 void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 {
-	//TODO //FIXME //TO TEST
-	bcf_srs_t * sr_scan =  bcf_sr_init();
-
-	initReader(sr_scan, fmain, nthreads);
-	M.n_tar_samples = bcf_hdr_nsamples(sr_scan->readers[0].header);
-	M.tar_sample_names = std::vector<std::string> (M.n_tar_samples);
-
-	for (int i = 0 ; i < M.n_tar_samples ; i ++)
-		M.tar_sample_names[i] = std::string(sr_scan->readers[0].header->samples[i]);
-
+	//One-time header setup (sample names + ploidy; set_ploidy_tar also allocates the
+	//genotype set, so it must run exactly once). Open/index errors here are already
+	//fatal via initReader; only the streaming passes below are retried.
+	{
+		bcf_srs_t * sr_hdr = bcf_sr_init();
+		initReader(sr_hdr, fmain, nthreads);
+		M.n_tar_samples = bcf_hdr_nsamples(sr_hdr->readers[0].header);
+		M.tar_sample_names = std::vector<std::string> (M.n_tar_samples);
+		for (int i = 0 ; i < M.n_tar_samples ; i ++)
+			M.tar_sample_names[i] = std::string(sr_hdr->readers[0].header->samples[i]);
+		bcf_sr_destroy(sr_hdr);
+	}
 	set_ploidy_tar();
 
+	std::vector<variant*> vec_pos_tar;
+
+	//Retries are not implemented in hfile_libcurl (used when streaming from a cloud
+	//location), so we retry transient read failures of each streaming pass here. The
+	//scan only accumulates into the local vec_pos_tar (reset by clearing it at the
+	//start of scanTarGenotypes), and the parse overwrites the genotype set by site
+	//index, so each retry restarts the pass from a clean state.
 	vrb.wait("  * VCF/BCF scanning");
 	tac.clock();
+	{
+		const int n_retry = 3;
+		int n_retry_remain = n_retry;
+		std::chrono::seconds delay(1);
+		for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
+		{
+			if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
+			const int err = scanTarGenotypes(fmain, nthreads, vec_pos_tar);
+			if (err)
+			{
+				vrb.warning("Error while scanning [" + fmain + "]: " + std::string(bcf_sr_strerror(err)) + ". " + std::to_string(n_retry_remain) + " retries remaining");
+				continue;
+			}
+			break;
+		}
+		if (n_retry_remain == 0) vrb.error("Max number of retries attempted while scanning [" + fmain + "]");
+	}
 
-	//Scan file
-	bcf1_t * line_main = NULL;
-	int npl_main, npl_arr_main = 0, *pl_arr_main = NULL;
-	int ngl_main, ngl_arr_main = 0;
-	float *gl_arr_main = NULL;
-	const int max_ploidyP1=H.max_ploidy+1;
-	int *ptr;
-	int main_file_max_ploidy=0;
-	float *ptr_f;
-	std::vector<variant*> vec_pos_tar;
+	vrb.wait("  * VCF/BCF parsing");
+	tac.clock();
+	{
+		const int n_retry = 3;
+		int n_retry_remain = n_retry;
+		std::chrono::seconds delay(1);
+		for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
+		{
+			if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
+			const int err = parseTarGenotypes(fmain, nthreads, vec_pos_tar);
+			if (err)
+			{
+				vrb.warning("Error while parsing [" + fmain + "]: " + std::string(bcf_sr_strerror(err)) + ". " + std::to_string(n_retry_remain) + " retries remaining");
+				continue;
+			}
+			break;
+		}
+		if (n_retry_remain == 0) vrb.error("Max number of retries attempted while parsing [" + fmain + "]");
+	}
+}
+
+int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar)
+{
+	vec_pos_tar.clear(); //reset any partial accumulation from a failed attempt
+
+	bcf_srs_t * sr_scan = bcf_sr_init();
+	initReader(sr_scan, fmain, nthreads);
 	sr_scan->max_unpack = BCF_UN_INFO;
 
+	bcf1_t * line_main = NULL;
 	while (bcf_sr_next_line (sr_scan))
 	{
 		if (!bcf_sr_has_line(sr_scan, 0) || bcf_sr_get_line(sr_scan, 0)->n_allele != 2) continue; //always ref
@@ -307,18 +354,27 @@ void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 		if (vecS.size() > 0) vec_pos_tar.push_back(vecS[0]);
 		else vec_pos_tar.push_back(nullptr);
 	}
-
+	const int err = sr_scan->errnum;
 	bcf_sr_destroy(sr_scan);
+	return err;
+}
 
-	vrb.wait("  * VCF/BCF parsing");
-	tac.clock();
+int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar)
+{
+	bcf1_t * line_main = NULL;
+	int npl_main, npl_arr_main = 0, *pl_arr_main = NULL;
+	int ngl_main, ngl_arr_main = 0;
+	float *gl_arr_main = NULL;
+	const int max_ploidyP1=H.max_ploidy+1;
+	int *ptr;
+	int main_file_max_ploidy=0;
+	float *ptr_f;
+	int i_site=0;
+	const int n_ref_haps = H.n_ref_haps;
 
 	bcf_srs_t * sr_parse =  bcf_sr_init();
 	initReader(sr_parse, fmain, nthreads);
-	int i_site=0;
-
 	sr_parse->max_unpack = BCF_UN_ALL;
-	const int n_ref_haps = H.n_ref_haps;
 
 	while (bcf_sr_next_line (sr_parse))
 	{
@@ -410,9 +466,11 @@ void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 			++i_site;
 		}
 	}
+	const int err = sr_parse->errnum;
 	bcf_sr_destroy(sr_parse);
 	free(pl_arr_main);
 	free(gl_arr_main);
+	return err;
 }
 
 void genotype_reader::set_ploidy_tar()
@@ -642,6 +700,7 @@ void genotype_reader::parseGenotypes(bcf_srs_t * sr) {
 		prog_bar+=prog_step;
 		vrb.progress("  * VCF/BCF parsing", prog_bar);
 	}
+	if (sr->errnum) vrb.error("Error while parsing VCF/BCF file(s): " + std::string(bcf_sr_strerror(sr->errnum)));
 	free(pl_arr_main);
 	free(gl_arr_main);
 	free(gt_arr_ref);
@@ -700,6 +759,7 @@ void genotype_reader::parseRefGenotypes(bcf_srs_t * sr) {
 		prog_bar+=prog_step;
 		vrb.progress("  * Reference panel parsing ", prog_bar);
 	}
+	if (sr->errnum) vrb.error("Error while parsing reference panel: " + std::string(bcf_sr_strerror(sr->errnum)));
 	free(gt_arr_ref);
 
 	// Report

--- a/phase/src/io/genotype_reader.cpp
+++ b/phase/src/io/genotype_reader.cpp
@@ -24,6 +24,7 @@
  ******************************************************************************/
 
 #include <io/genotype_reader.h>
+#include <io/retry_io.h>
 #include <thread>
 #include <chrono>
 
@@ -136,6 +137,22 @@ void genotype_reader::initReader(bcf_srs_t *sr, std::string& file, int nthreads)
 		if (sr->errnum != idx_load_failed) vrb.error("Failed to open file: " + file + "");
 		else vrb.error("Failed to load index of the file: " + file + "");
 	}
+}
+
+int genotype_reader::openTargetReader(bcf_srs_t *sr, std::string& file, int nthreads)
+{
+	sr->require_index = 1;
+	//Region/target setup failures are deterministic config errors, not transient cloud
+	//hiccups, so they stay fatal.
+	if (bcf_sr_set_regions(sr, V.input_gregion.c_str(), 0) == -1) vrb.error("Impossible to jump to region [" + V.input_gregion + "] in [" + file + "]");
+	if (bcf_sr_set_targets(sr, V.input_gregion.c_str(), 0, 0) == -1) vrb.error("Impossible to set target region [" + V.input_gregion + "] in [" + file + "]");
+
+	if (nthreads>1) bcf_sr_set_threads(sr, nthreads);
+
+	//A failed open/index load is the most common transient cloud-streaming failure;
+	//return the errnum (nonzero) so the caller can retry instead of aborting here.
+	if(!(bcf_sr_add_reader (sr, file.c_str()))) return sr->errnum ? sr->errnum : -1;
+	return 0;
 }
 
 void genotype_reader::readGenotypesAndBAMs(std::string fref,int nthreads)
@@ -275,67 +292,35 @@ void genotype_reader::scanGenotypes(bcf_srs_t * sr) {
 }
 void genotype_reader::readTarGenotypes(std::string fmain, int nthreads)
 {
-	//One-time header setup (sample names + ploidy; set_ploidy_tar also allocates the
-	//genotype set, so it must run exactly once). Open/index errors here are already
-	//fatal via initReader; only the streaming passes below are retried.
-	{
-		bcf_srs_t * sr_hdr = bcf_sr_init();
-		initReader(sr_hdr, fmain, nthreads);
-		M.n_tar_samples = bcf_hdr_nsamples(sr_hdr->readers[0].header);
-		M.tar_sample_names = std::vector<std::string> (M.n_tar_samples);
-		for (int i = 0 ; i < M.n_tar_samples ; i ++)
-			M.tar_sample_names[i] = std::string(sr_hdr->readers[0].header->samples[i]);
-		bcf_sr_destroy(sr_hdr);
-	}
-	set_ploidy_tar();
+	//Retries are not implemented in hfile_libcurl (used when streaming from a cloud
+	//location), so we retry transient read failures of each streaming pass here. The
+	//scan only accumulates into the local vec_pos_tar (reset by clearing it at the start
+	//of scanTarGenotypes) and reads the sample names/header, and the parse overwrites the
+	//genotype set by site index, so each retry restarts the pass from a clean state.
+	vrb.bullet("Reading target GLs from [" + fmain + "] via retry-enabled streaming path (binary reference panel)");
+	const int n_retry = 3;
+	const std::chrono::seconds base_delay(1);
 
 	std::vector<variant*> vec_pos_tar;
 
-	//Retries are not implemented in hfile_libcurl (used when streaming from a cloud
-	//location), so we retry transient read failures of each streaming pass here. The
-	//scan only accumulates into the local vec_pos_tar (reset by clearing it at the
-	//start of scanTarGenotypes), and the parse overwrites the genotype set by site
-	//index, so each retry restarts the pass from a clean state.
-	vrb.bullet("Reading target GLs from [" + fmain + "] via retry-enabled streaming path (binary reference panel)");
 	vrb.wait("  * VCF/BCF scanning");
 	tac.clock();
-	{
-		const int n_retry = 3;
-		int n_retry_remain = n_retry;
-		std::chrono::seconds delay(1);
-		for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
-		{
-			if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
-			const int err = scanTarGenotypes(fmain, nthreads, vec_pos_tar);
-			if (err)
-			{
-				vrb.warning("Error while scanning [" + fmain + "]: " + std::string(bcf_sr_strerror(err)) + ". " + std::to_string(n_retry_remain) + " retries remaining");
-				continue;
-			}
-			break;
-		}
-		if (n_retry_remain == 0) vrb.error("Max number of retries attempted while scanning [" + fmain + "]");
-	}
+	retry_with_backoff("scanning target GLs [" + fmain + "]", n_retry, base_delay, [&]() -> attempt_result {
+		const int err = scanTarGenotypes(fmain, nthreads, vec_pos_tar);
+		return { err == 0, false, err ? std::string(bcf_sr_strerror(err)) : std::string() };
+	});
+
+	//Sample names + ploidy are now known from the (retried) scan pass; set_ploidy_tar
+	//allocates the genotype set, so it must run exactly once, after a successful scan and
+	//before the parse pass writes into it.
+	set_ploidy_tar();
 
 	vrb.wait("  * VCF/BCF parsing");
 	tac.clock();
-	{
-		const int n_retry = 3;
-		int n_retry_remain = n_retry;
-		std::chrono::seconds delay(1);
-		for (; n_retry_remain > 0; n_retry_remain--, delay *= 2)
-		{
-			if (n_retry_remain != n_retry) std::this_thread::sleep_for(delay);
-			const int err = parseTarGenotypes(fmain, nthreads, vec_pos_tar);
-			if (err)
-			{
-				vrb.warning("Error while parsing [" + fmain + "]: " + std::string(bcf_sr_strerror(err)) + ". " + std::to_string(n_retry_remain) + " retries remaining");
-				continue;
-			}
-			break;
-		}
-		if (n_retry_remain == 0) vrb.error("Max number of retries attempted while parsing [" + fmain + "]");
-	}
+	retry_with_backoff("parsing target GLs [" + fmain + "]", n_retry, base_delay, [&]() -> attempt_result {
+		const int err = parseTarGenotypes(fmain, nthreads, vec_pos_tar);
+		return { err == 0, false, err ? std::string(bcf_sr_strerror(err)) : std::string() };
+	});
 }
 
 int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar)
@@ -343,8 +328,16 @@ int genotype_reader::scanTarGenotypes(std::string fmain, int nthreads, std::vect
 	vec_pos_tar.clear(); //reset any partial accumulation from a failed attempt
 
 	bcf_srs_t * sr_scan = bcf_sr_init();
-	initReader(sr_scan, fmain, nthreads);
+	const int open_err = openTargetReader(sr_scan, fmain, nthreads);
+	if (open_err) { bcf_sr_destroy(sr_scan); return open_err; }
 	sr_scan->max_unpack = BCF_UN_INFO;
+
+	//Read sample names/header from this (retried) pass, so a transient open failure here
+	//is retried rather than aborting the run in a separate, un-retried header open.
+	M.n_tar_samples = bcf_hdr_nsamples(sr_scan->readers[0].header);
+	M.tar_sample_names = std::vector<std::string> (M.n_tar_samples);
+	for (int i = 0 ; i < M.n_tar_samples ; i ++)
+		M.tar_sample_names[i] = std::string(sr_scan->readers[0].header->samples[i]);
 
 	bcf1_t * line_main = NULL;
 	while (bcf_sr_next_line (sr_scan))
@@ -375,12 +368,18 @@ int genotype_reader::parseTarGenotypes(std::string fmain, int nthreads, const st
 	const int n_ref_haps = H.n_ref_haps;
 
 	bcf_srs_t * sr_parse =  bcf_sr_init();
-	initReader(sr_parse, fmain, nthreads);
+	const int open_err = openTargetReader(sr_parse, fmain, nthreads);
+	if (open_err) { bcf_sr_destroy(sr_parse); return open_err; }
 	sr_parse->max_unpack = BCF_UN_ALL;
 
 	while (bcf_sr_next_line (sr_parse))
 	{
 		if (!bcf_sr_has_line(sr_parse, 0) || bcf_sr_get_line(sr_parse, 0)->n_allele != 2) continue; //always ref
+		//The scan and parse passes are independent re-opens; if the parse pass yields more
+		//surviving sites than the scan recorded (e.g. the file changed between passes),
+		//indexing vec_pos_tar[i_site] would read past its end. Fail loudly instead.
+		if (i_site >= (int)vec_pos_tar.size())
+			vrb.error("Target GL file [" + fmain + "] returned more sites while parsing than while scanning (" + std::to_string(vec_pos_tar.size()) + "). The file may have changed between the two streaming passes.");
 		if (vec_pos_tar[i_site] == nullptr)
 		{
 			++i_site;

--- a/phase/src/io/genotype_reader.h
+++ b/phase/src/io/genotype_reader.h
@@ -69,6 +69,10 @@ public:
 
 	void scanGenotypes(bcf_srs_t * sr);
 	void readTarGenotypes(std::string , int);
+	//One streaming pass each over the target GL file. Return the synced-reader errnum
+	//(0 on success) so the caller can retry transient cloud-streaming read failures.
+	int scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar);
+	int parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar);
 	//void readTarGenotypesValidation(string, string, int);
 
 	void parseGenotypes(bcf_srs_t * sr);

--- a/phase/src/io/genotype_reader.h
+++ b/phase/src/io/genotype_reader.h
@@ -69,16 +69,21 @@ public:
 	//Non-fatal open of a single (cloud-streamed) target file. Region/target setup errors
 	//are deterministic and stay fatal, but a failed open/index load returns the
 	//synced-reader errnum (nonzero) instead of exiting, so the streaming passes can retry
-	//a transient open failure rather than aborting the whole run on it.
-	int openTargetReader(bcf_srs_t * sr, std::string& file, int nthreads);
+	//a transient open failure rather than aborting the whole run on it. On failure err_out
+	//is filled with a human-readable description.
+	int openTargetReader(bcf_srs_t * sr, std::string& file, int nthreads, std::string& err_out);
 
 	void scanGenotypes(bcf_srs_t * sr);
 	void readTarGenotypes(std::string , int);
-	//One streaming pass each over the target GL file. Return the synced-reader errnum
-	//(0 on success) so the caller can retry transient cloud-streaming read failures. The
-	//scan pass also reads the sample names/header (so no separate header open is needed).
-	int scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar);
-	int parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar);
+	//One streaming pass each over the target GL file. Return 0 on success or a nonzero code
+	//(synced-reader errnum, or one of the SR_* sentinels) so the caller can retry transient
+	//cloud-streaming failures; on failure err_out is filled with a description. The scan
+	//pass also reads the sample names/header (so no separate header open is needed). Note:
+	//htslib does not reliably set errnum on a mid-stream read failure (and open_failed==0),
+	//so a truncated pass can return 0; the parse pass cross-checks its site count against
+	//the scan to catch that case (see SR_TRUNCATED).
+	int scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar, std::string& err_out);
+	int parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar, std::string& err_out);
 	//void readTarGenotypesValidation(string, string, int);
 
 	void parseGenotypes(bcf_srs_t * sr);

--- a/phase/src/io/genotype_reader.h
+++ b/phase/src/io/genotype_reader.h
@@ -66,11 +66,17 @@ public:
 
 	void initReader(bcf_srs_t * sr, std::string& fmain, std::string& fref, int nthreads);
 	void initReader(bcf_srs_t * sr, std::string& file, int nthreads);
+	//Non-fatal open of a single (cloud-streamed) target file. Region/target setup errors
+	//are deterministic and stay fatal, but a failed open/index load returns the
+	//synced-reader errnum (nonzero) instead of exiting, so the streaming passes can retry
+	//a transient open failure rather than aborting the whole run on it.
+	int openTargetReader(bcf_srs_t * sr, std::string& file, int nthreads);
 
 	void scanGenotypes(bcf_srs_t * sr);
 	void readTarGenotypes(std::string , int);
 	//One streaming pass each over the target GL file. Return the synced-reader errnum
-	//(0 on success) so the caller can retry transient cloud-streaming read failures.
+	//(0 on success) so the caller can retry transient cloud-streaming read failures. The
+	//scan pass also reads the sample names/header (so no separate header open is needed).
 	int scanTarGenotypes(std::string fmain, int nthreads, std::vector<variant*>& vec_pos_tar);
 	int parseTarGenotypes(std::string fmain, int nthreads, const std::vector<variant*>& vec_pos_tar);
 	//void readTarGenotypesValidation(string, string, int);

--- a/phase/src/io/retry_io.h
+++ b/phase/src/io/retry_io.h
@@ -28,10 +28,6 @@ struct attempt_result
 //attempts still remaining. A fatal outcome aborts immediately via vrb.error; exhausting
 //all attempts also aborts via vrb.error. `what` names the action for the log messages,
 //e.g. "reading binary reference panel [path]".
-//
-//Note: this is a new phase-local header. If ligate/concordance ever grow the same
-//retry need, we should move it to common/src/utils/ with symlinks
-    — but I kept it phase-local to avoid touching the shared tree unnecessarily.
 template <typename Fn>
 void retry_with_backoff(const std::string& what, int n_retry, std::chrono::seconds base_delay, Fn&& attempt)
 {

--- a/phase/src/io/retry_io.h
+++ b/phase/src/io/retry_io.h
@@ -29,9 +29,9 @@ struct attempt_result
 //all attempts also aborts via vrb.error. `what` names the action for the log messages,
 //e.g. "reading binary reference panel [path]".
 //
-//The retry idiom used to be hand-copied across the cloud-streamed read paths; this is the
-//single source of truth so the schedule and the "attempts remaining" count stay correct
-//and consistent everywhere.
+//Note: this is a new phase-local header. If ligate/concordance ever grow the same
+//retry need, we should move it to common/src/utils/ with symlinks
+    — but I kept it phase-local to avoid touching the shared tree unnecessarily.
 template <typename Fn>
 void retry_with_backoff(const std::string& what, int n_retry, std::chrono::seconds base_delay, Fn&& attempt)
 {

--- a/phase/src/io/retry_io.h
+++ b/phase/src/io/retry_io.h
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (C) 2022-2023 Simone Rubinacci
+ * Copyright (C) 2022-2023 Olivier Delaneau
+ *
+ * MIT Licence
+ ******************************************************************************/
+
+#ifndef _RETRY_IO_H
+#define _RETRY_IO_H
+
+#include <string>
+#include <chrono>
+#include <thread>
+
+#include <utils/otools.h>
+
+//Outcome of one attempt passed to retry_with_backoff.
+struct attempt_result
+{
+	bool ok = false;      //attempt succeeded: stop and return
+	bool fatal = false;   //failure is non-retryable: abort immediately, do not retry
+	std::string err;      //human-readable error, used in the warning/error messages
+};
+
+//Retry `attempt` up to n_retry times with exponential backoff. With n_retry=3 and
+//base_delay=1s the attempts are separated by 1s then 2s sleeps (no sleep before the
+//first attempt). Between failed attempts a warning is logged with the correct number of
+//attempts still remaining. A fatal outcome aborts immediately via vrb.error; exhausting
+//all attempts also aborts via vrb.error. `what` names the action for the log messages,
+//e.g. "reading binary reference panel [path]".
+//
+//The retry idiom used to be hand-copied across the cloud-streamed read paths; this is the
+//single source of truth so the schedule and the "attempts remaining" count stay correct
+//and consistent everywhere.
+template <typename Fn>
+void retry_with_backoff(const std::string& what, int n_retry, std::chrono::seconds base_delay, Fn&& attempt)
+{
+	std::chrono::seconds delay = base_delay;
+	for (int i = 0; i < n_retry; ++i)
+	{
+		const attempt_result r = attempt();
+		if (r.ok) return;
+		if (r.fatal) vrb.error("Non-retryable error while " + what + ": " + r.err);
+
+		const int attempts_left = n_retry - i - 1;
+		if (attempts_left > 0)
+		{
+			vrb.warning("Error while " + what + ": " + r.err + ". " + std::to_string(attempts_left) + " attempt(s) remaining");
+			std::this_thread::sleep_for(delay);
+			delay *= 2;
+		}
+		else vrb.error("Max number of retries attempted while " + what + ". Last error: " + r.err);
+	}
+}
+
+#endif


### PR DESCRIPTION
Fix for input and reference panel streaming, using https://github.com/odelaneau/GLIMPSE/pull/212 as a model.

Goal: Make GLIMPSE2_phase resilient to transient read failures when inputs are streamed/localized from a cloud filesystem, by retrying with exponential backoff instead of crashing on the first error — while still failing fast on errors that retrying can't fix.

Two areas in *phase* changed:
1. Target GL streaming — phase/src/io/genotype_reader.cpp / .h
2. Binary reference panel localization — phase/src/caller/caller_initialise.cpp / caller_header.h

In *ligate* and *concordance*, we've added explicit error messages to avoid silent failures, but adding retries would be more complex than I'd like to include in this PR.

Testing:
I ran the same GlimpsePhase task N times in parallel, on the same reference panel chunk and VCF input, and checked the crc values Glimpse calculated for the inputs in the checkpointing file. 
- As a positive control, I ran this before applying the changes in this PR, and 9/5000 tasks had bad checksums. 
- I ran a different test with the logs here but no Glimpse retries and 11/8,000 tasks had bad checksums
- After these changes, 0/8,000 tasks had bad checksums, indicating the issue is resolved

Checked the logs for the runs with these changes and found 5 instances of errors that were retried once:
<img width="1217" height="195" alt="image" src="https://github.com/user-attachments/assets/b3e3dc57-9a6d-4045-9eaa-4cc35e880660" />

I also confirmed that the output of phase is identical before and after these changes.