### PR TITLE
Fix integer truncation of buffer cM spans in add_buffer

### DIFF
--- a/chunk/src/chunker/chunker_algorithm.cpp
+++ b/chunk/src/chunker/chunker_algorithm.cpp
@@ -169,7 +169,8 @@ void chunker::split_sequential(output_file & fd, long int & cidx, std::string & 
 
 void chunker::add_buffer(const long int start_idx, const long int stop_idx, long int& left_idx, long int& right_idx)
 {
-	long int left_mb_size = -1, left_cm_size = -1, left_count = -1;
+	long int left_mb_size = -1, left_count = -1;
+	double left_cm_size = -1;
 	if (start_idx > buffer_count) {
 		left_idx = start_idx - buffer_count;
 		do {
@@ -180,7 +181,8 @@ void chunker::add_buffer(const long int start_idx, const long int stop_idx, long
 		} while (((left_idx > 0) && ((left_cm_size < buffer_cm) || (left_mb_size < buffer_mb) || left_count < buffer_count)));
 	} else { left_idx = 0; }
 
-	long int right_mb_size = -1, right_cm_size = -1, right_count = -1;
+	long int right_mb_size = -1, right_count = -1;
+	double right_cm_size = -1;
 	if (stop_idx < (positions_all_mb.size() - buffer_count)) {
 		right_idx = stop_idx + buffer_count - 1;
 		do {


### PR DESCRIPTION
GLIMPSE2_chunk specifies a default `--buffer-cm` of 0.5, but internally the accumulated buffer cM is tracked as an integer, and therefore any non-integer value for `--buffer-cm` is effectively treated (silently) as the next integer.  I.e. 0.5 yields a minimum of 1.0, 1.1 yields a minimum of 2.0 etc. because the float value is truncated to an int before storage.

This PR changes the incremental buffer cm tracking to use floats, which matches the apparent intent from the command line defaults, _and_ matches the pre-existing use of floats internally for the window-cm tracking.