### PR TITLE
Fix --buffer-count to count common variants, not all variants

### DIFF
--- a/chunk/src/chunker/chunker_algorithm.cpp
+++ b/chunk/src/chunker/chunker_algorithm.cpp
@@ -169,27 +169,34 @@ void chunker::split_sequential(output_file & fd, long int & cidx, std::string & 
 
 void chunker::add_buffer(const long int start_idx, const long int stop_idx, long int& left_idx, long int& right_idx)
 {
+	const long int n_all = (long int) positions_all_mb.size();
+	const long int n_common = (long int) positions_common_mb.size();
+
 	long int left_mb_size = -1, left_cm_size = -1, left_count = -1;
-	if (start_idx > buffer_count) {
-		left_idx = start_idx - buffer_count;
-		do {
-			left_idx --;
-			left_count = start_idx - left_idx + 1;
-			left_mb_size = positions_all_mb[start_idx] - positions_all_mb[left_idx];
-			left_cm_size = positions_all_cm[start_idx] - positions_all_cm[left_idx];
-		} while (((left_idx > 0) && ((left_cm_size < buffer_cm) || (left_mb_size < buffer_mb) || left_count < buffer_count)));
+	if (all2common[start_idx] >= buffer_count) {
+		left_idx = common2all[all2common[start_idx] - buffer_count];
+		if (left_idx > 0) {
+			do {
+				left_idx--;
+				left_count = all2common[start_idx] - all2common[left_idx];
+				left_mb_size = positions_all_mb[start_idx] - positions_all_mb[left_idx];
+				left_cm_size = positions_all_cm[start_idx] - positions_all_cm[left_idx];
+			} while ((left_idx > 0) && ((left_cm_size < buffer_cm) || (left_mb_size < buffer_mb) || left_count < buffer_count));
+		}
 	} else { left_idx = 0; }
 
 	long int right_mb_size = -1, right_cm_size = -1, right_count = -1;
-	if (stop_idx < (positions_all_mb.size() - buffer_count)) {
-		right_idx = stop_idx + buffer_count - 1;
-		do {
-			right_idx ++;
-			right_count = right_idx - stop_idx + 1;
-			right_mb_size = positions_all_mb[right_idx] - positions_all_mb[stop_idx];
-			right_cm_size = positions_all_cm[right_idx] - positions_all_cm[stop_idx];
-		} while (((right_idx < (positions_all_mb.size() - 1)) && ((right_cm_size < buffer_cm) || (right_mb_size < buffer_mb) || right_count < buffer_count)));
-	} else { right_idx = positions_all_mb.size() - 1; }
+	if (all2common[stop_idx] + buffer_count < n_common) {
+		right_idx = common2all[all2common[stop_idx] + buffer_count];
+		if (right_idx < n_all - 1) {
+			do {
+				right_idx++;
+				right_count = all2common[right_idx] - all2common[stop_idx];
+				right_mb_size = positions_all_mb[right_idx] - positions_all_mb[stop_idx];
+				right_cm_size = positions_all_cm[right_idx] - positions_all_cm[stop_idx];
+			} while ((right_idx < n_all - 1) && ((right_cm_size < buffer_cm) || (right_mb_size < buffer_mb) || right_count < buffer_count));
+		}
+	} else { right_idx = n_all - 1; }
 }
 
 void chunker::chunk() {

--- a/chunk/src/chunker/chunker_parameters.cpp
+++ b/chunk/src/chunker/chunker_parameters.cpp
@@ -104,14 +104,14 @@ void chunker::check_options() {
 	if (options["window-mb"].as < float > () <= 0)
 		vrb.error("Window size in Mb must be positive");
 	if (options["window-count"].as < long int > () <= 0)
-		vrb.error("Window size in number of markers must be positive");
+		vrb.error("Window size in number of common variants must be positive");
 
 	if (options["buffer-cm"].as < float > () <= 0)
 		vrb.error("Buffer size in cM must be positive");
 	if (options["buffer-mb"].as < float > () <= 0)
 		vrb.error("Buffer size in Mb must be positive");
 	if (options["buffer-count"].as < long int > () <= 0)
-		vrb.error("Buffer size in number of markers must be positive");
+		vrb.error("Buffer size in number of common variants must be positive");
 
 	float s_maf = options["sparse-maf"].as < float > ();
 	if (s_maf >= 0.5 || s_maf < 0) vrb.error("The sparse MAF parameter should not be set too high or low. Ideally within the range [0.01-0.001] 0.001 MAF is the recommended setting]");
@@ -144,8 +144,8 @@ void chunker::verbose_options() {
 	vrb.bullet("Sparse MAF           : [" + stb.str(options["sparse-maf"].as < float > ()) + "]");
 	vrb.bullet("Algorithm            : [" + opt_algo + "]");
 	vrb.bullet("Recombination rates  : [" + opt_map + "]");
-	vrb.bullet("Min. Window size     : [" + stb.str(options["window-cm"].as < float > ()) + "cM | " + stb.str(options["window-mb"].as < float > ()) + "Mb | " + stb.str(options["window-count"].as < long int > ()) + " variants]");
-	vrb.bullet("Min. Buffer size     : [" + stb.str(options["buffer-cm"].as < float > ()) + "cM | " + stb.str(options["buffer-mb"].as < float > ()) + "Mb | " + stb.str(options["buffer-count"].as < long int > ()) + " variants]");
+	vrb.bullet("Min. Window size     : [" + stb.str(options["window-cm"].as < float > ()) + "cM | " + stb.str(options["window-mb"].as < float > ()) + "Mb | " + stb.str(options["window-count"].as < long int > ()) + " common variants]");
+	vrb.bullet("Min. Buffer size     : [" + stb.str(options["buffer-cm"].as < float > ()) + "cM | " + stb.str(options["buffer-mb"].as < float > ()) + "Mb | " + stb.str(options["buffer-count"].as < long int > ()) + " common variants]");
 
 	vrb.title("Other parameters");
 	vrb.bullet("Seed                 : [" + stb.str(options["seed"].as < long int > ()) + "]");

--- a/docs/docs/documentation/chunk.md
+++ b/docs/docs/documentation/chunk.md
@@ -55,10 +55,10 @@ GLIMPSE2_chunk --input file_chr20.bcf --map chr20.b38.gmap.gz --region chr20 --s
 |:---------------------|:--------|:---------|:-------------------------------------|
 | \-\-window-cm        | FLOAT   | 2.5     | Minimal window size in cM |
 | \-\-window-mb        | FLOAT   | 2.0     | Minimal window size in Mb |
-| \-\-window-count     | INT     | 20000   | Minimal window size in #variants |
+| \-\-window-count     | INT     | 20000   | Minimal window size in #common variants |
 | \-\-buffer-cm        | FLOAT   | 0.5     | Minimal buffer size in cM |
 | \-\-buffer-mb        | FLOAT   | 0.4     | Minimal buffer size in Mb |
-| \-\-buffer-count     | INT     | 2000    | Minimal buffer size in #variants |
+| \-\-buffer-count     | INT     | 2000    | Minimal buffer size in #common variants |
 
 #### Model Parameters
 


### PR DESCRIPTION
The --buffer-count option is documented as counting common variants (MAF >= sparse-maf), matching --window-count which already counts common variants correctly.  

See https://github.com/odelaneau/GLIMPSE/blob/master/chunk/src/chunker/chunker_parameters.cpp#L50

However, add_buffer computed left_count and right_count as raw index distances over the all-variants arrays, counting every variant (common + rare) toward the threshold.

This PR fixes add_buffer to use the all2common/common2all mappings to:
- Guard on whether enough common variants exist for a buffer
- Jump to the correct starting position in common-variant space
- Count only common variants toward the buffer_count threshold

It also updates docs and verbose output to consistently say "common variants" for both --window-count and --buffer-count.

This is a behavior change: realized buffers will be wider wherever the count floor binds, because buffer_count common variants span more total variants than buffer_count all-variants. This matches the documented and intended semantics.  Although, taken with https://github.com/odelaneau/GLIMPSE/pull/310 the effect will be lower than expected at default parameters.