### PR TITLE
Fix lost phase assignment for uncovered hets in phasing_hmm::rephaseHaplotypes

### DIFF
--- a/phase/src/models/phasing_hmm.cpp
+++ b/phase/src/models/phasing_hmm.cpp
@@ -279,9 +279,10 @@ void phasing_hmm::rephaseHaplotypes(std::vector < bool > & H0, std::vector < boo
 			p01 = std::clamp(p01/sum, 0.0f,1.0f);
 			p10 = std::clamp(p10/sum, 0.0f,1.0f);
 			sum = p01+p10;
+			//rf==true selects the p01 configuration, i.e. H0 carries allele 0 and H1 allele 1
 			const bool rf = (rng.getFloat()*sum) < p01;
-			H0[VAR_ABS[curr_idx_locus]] = rf;
 			H0[VAR_ABS[curr_idx_locus]] = !rf;
+			H1[VAR_ABS[curr_idx_locus]] = rf;
 			curr_missing_locus++;
 		}
 		curr_segment_locus ++;


### PR DESCRIPTION
In `phasing_hmm::rephaseHaplotypes`, the `VAR_FLAT_HET` branch samples a phase orientation for hets at uncovered sites from the segment-conditioned posteriors, but then assigns both results to `H0`:

```cpp
const bool rf = (rng.getFloat()*sum) < p01;
H0[VAR_ABS[curr_idx_locus]] = rf;
H0[VAR_ABS[curr_idx_locus]] = !rf;
```

The first store is dead and `H1` is never written, so the sampled phase is discarded and `H1` keeps its value from `sampleHaplotypeH1`. Roughly half the time `!rf` equals that stale allele and the het silently collapses to a homozygote in the working haplotypes, which feed both the stored output haplotypes and the next iteration's haplotype updates. The bug has been present since v2.0.0 (1a9826a).

This PR assigns the sampled configuration to both haplotypes. Note the orientation: `rf` is true when the draw selects `p01`, which is constructed as the likelihood that H0 carries allele 0 and H1 carries allele 1 (`p01 = (h0a0*ee + h0a1*ed) * (h1a1*ee + h1a0*ed)`), so the correct assignment is `H0 = !rf; H1 = rf` — the surviving line was already the correct `H0`; the missing piece was `H1 = rf`. A "fix" that only renamed the second line's `H0` to `H1` (i.e. `H0 = rf; H1 = !rf`) would sample the two orientations with swapped probabilities.

The fix changes output, as expected for a phasing correction. On a 484k-site chunk of a 992-cat panel imputed at 0.2x and 2x coverage (single sample, default settings), genotypes and dosages move less than or on par with a seed change (unphased GT discordance 0.089% at 0.2x / 0.029% at 2x vs. a measured seed-to-seed noise floor of 0.093% / 0.034%; dosage RMSD likewise at the noise floor), while the phased GT orientation changes at ~7.2k (0.2x) and ~9.2k (2x) sites — i.e. the phase of low-coverage hets is what the fix actually affects.
